### PR TITLE
[codex] add terrain-aware navigation baseline

### DIFF
--- a/TerminatorPlus-API/src/main/java/net/nuggetmc/tplus/api/agent/legacyagent/BlockKey.java
+++ b/TerminatorPlus-API/src/main/java/net/nuggetmc/tplus/api/agent/legacyagent/BlockKey.java
@@ -1,0 +1,19 @@
+package net.nuggetmc.tplus.api.agent.legacyagent;
+
+import org.bukkit.Location;
+import org.bukkit.World;
+import org.bukkit.block.Block;
+
+record BlockKey(int x, int y, int z) {
+    static BlockKey of(Block block) {
+        return new BlockKey(block.getX(), block.getY(), block.getZ());
+    }
+
+    Block block(World world) {
+        return world.getBlockAt(x, y, z);
+    }
+
+    Location center(World world) {
+        return new Location(world, x + 0.5, y + 0.5, z + 0.5);
+    }
+}

--- a/TerminatorPlus-API/src/main/java/net/nuggetmc/tplus/api/agent/legacyagent/LegacyMovementStrategy.java
+++ b/TerminatorPlus-API/src/main/java/net/nuggetmc/tplus/api/agent/legacyagent/LegacyMovementStrategy.java
@@ -5,15 +5,18 @@ import org.bukkit.Location;
 import org.bukkit.entity.LivingEntity;
 
 /**
- * Compatibility movement strategy. It delegates to LegacyAgent's current
- * legacy/full-NN/movement-controller move path unchanged.
+ * Compatibility movement strategy. It preserves full replacement NN behavior,
+ * keeps movement-controller NN as the first choice, and replaces the old direct
+ * legacy chase fallback with terrain-aware navigation.
  */
 final class LegacyMovementStrategy implements MovementStrategy {
 
     private final LegacyAgent legacy;
+    private final NavigationController navigation;
 
     LegacyMovementStrategy(LegacyAgent legacy) {
         this.legacy = legacy;
+        this.navigation = new NavigationController(legacy);
     }
 
     @Override
@@ -25,6 +28,26 @@ final class LegacyMovementStrategy implements MovementStrategy {
             LegacyAgent.MovementMode mode,
             boolean allowMovement
     ) {
+        if (mode == LegacyAgent.MovementMode.FULL_REPLACEMENT_NN) {
+            legacy.move(bot, target, botLocation, targetLocation, mode, allowMovement);
+            return;
+        }
+
+        if (mode == LegacyAgent.MovementMode.MOVEMENT_CONTROLLER_NN) {
+            if (allowMovement && bot.tryMovementControllerMove(target)) {
+                return;
+            }
+            if (navigation.handlesMovementControllerFallback()
+                    && navigation.move(bot, target, botLocation, targetLocation, mode, allowMovement)) {
+                return;
+            }
+            legacy.move(bot, target, botLocation, targetLocation, LegacyAgent.MovementMode.LEGACY, allowMovement);
+            return;
+        }
+
+        if (navigation.move(bot, target, botLocation, targetLocation, mode, allowMovement)) {
+            return;
+        }
         legacy.move(bot, target, botLocation, targetLocation, mode, allowMovement);
     }
 }

--- a/TerminatorPlus-API/src/main/java/net/nuggetmc/tplus/api/agent/legacyagent/NavAction.java
+++ b/TerminatorPlus-API/src/main/java/net/nuggetmc/tplus/api/agent/legacyagent/NavAction.java
@@ -1,0 +1,16 @@
+package net.nuggetmc.tplus.api.agent.legacyagent;
+
+import java.util.Objects;
+
+record NavAction(Type type, BlockKey block, String reason) {
+    NavAction {
+        Objects.requireNonNull(type, "type");
+        Objects.requireNonNull(block, "block");
+        reason = reason == null ? "" : reason;
+    }
+
+    enum Type {
+        OPEN,
+        BREAK
+    }
+}

--- a/TerminatorPlus-API/src/main/java/net/nuggetmc/tplus/api/agent/legacyagent/NavNode.java
+++ b/TerminatorPlus-API/src/main/java/net/nuggetmc/tplus/api/agent/legacyagent/NavNode.java
@@ -1,0 +1,27 @@
+package net.nuggetmc.tplus.api.agent.legacyagent;
+
+import org.bukkit.Location;
+import org.bukkit.World;
+
+record NavNode(int x, int y, int z) {
+    static NavNode from(Location location) {
+        return new NavNode(location.getBlockX(), location.getBlockY(), location.getBlockZ());
+    }
+
+    Location center(World world) {
+        return new Location(world, x + 0.5, y, z + 0.5);
+    }
+
+    double distanceSquared(Location location) {
+        double dx = x + 0.5 - location.getX();
+        double dy = y - location.getY();
+        double dz = z + 0.5 - location.getZ();
+        return dx * dx + dy * dy + dz * dz;
+    }
+
+    double horizontalDistanceSquared(Location location) {
+        double dx = x + 0.5 - location.getX();
+        double dz = z + 0.5 - location.getZ();
+        return dx * dx + dz * dz;
+    }
+}

--- a/TerminatorPlus-API/src/main/java/net/nuggetmc/tplus/api/agent/legacyagent/NavPath.java
+++ b/TerminatorPlus-API/src/main/java/net/nuggetmc/tplus/api/agent/legacyagent/NavPath.java
@@ -1,0 +1,41 @@
+package net.nuggetmc.tplus.api.agent.legacyagent;
+
+import java.util.List;
+
+final class NavPath {
+    private final TerrainPathfinder.SearchMode mode;
+    private final List<NavStep> steps;
+    private final int nodesConsidered;
+    private final String reason;
+
+    NavPath(TerrainPathfinder.SearchMode mode, List<NavStep> steps, int nodesConsidered, String reason) {
+        this.mode = mode;
+        this.steps = steps == null ? List.of() : List.copyOf(steps);
+        this.nodesConsidered = nodesConsidered;
+        this.reason = reason == null ? "" : reason;
+    }
+
+    TerrainPathfinder.SearchMode mode() {
+        return mode;
+    }
+
+    List<NavStep> steps() {
+        return steps;
+    }
+
+    int nodesConsidered() {
+        return nodesConsidered;
+    }
+
+    String reason() {
+        return reason;
+    }
+
+    boolean breakEnabled() {
+        return mode == TerrainPathfinder.SearchMode.ALLOW_BREAK;
+    }
+
+    boolean empty() {
+        return steps.isEmpty();
+    }
+}

--- a/TerminatorPlus-API/src/main/java/net/nuggetmc/tplus/api/agent/legacyagent/NavStep.java
+++ b/TerminatorPlus-API/src/main/java/net/nuggetmc/tplus/api/agent/legacyagent/NavStep.java
@@ -1,0 +1,10 @@
+package net.nuggetmc.tplus.api.agent.legacyagent;
+
+import java.util.List;
+
+record NavStep(NavNode node, List<NavAction> actions, String moveType, double cost) {
+    NavStep {
+        actions = actions == null ? List.of() : List.copyOf(actions);
+        moveType = moveType == null ? "walk" : moveType;
+    }
+}

--- a/TerminatorPlus-API/src/main/java/net/nuggetmc/tplus/api/agent/legacyagent/NavigationConfig.java
+++ b/TerminatorPlus-API/src/main/java/net/nuggetmc/tplus/api/agent/legacyagent/NavigationConfig.java
@@ -1,0 +1,68 @@
+package net.nuggetmc.tplus.api.agent.legacyagent;
+
+import org.bukkit.Bukkit;
+import org.bukkit.plugin.Plugin;
+
+record NavigationConfig(
+        boolean enabled,
+        boolean applyToMovementControllerFallback,
+        boolean suppressLegacyFallback,
+        boolean allowBreakFallback,
+        boolean allowDoors,
+        boolean allowTrapdoors,
+        boolean allowGates,
+        boolean avoidHazards,
+        int maxNodes,
+        int replanIntervalTicks,
+        int targetPredictTicks,
+        int maxDropBlocks,
+        double maxSearchDistance,
+        double goalRadius,
+        double lineOfSightGoalRadius
+) {
+    private static final String ROOT = "ai.navigation.";
+
+    static NavigationConfig load() {
+        Plugin plugin = Bukkit.getPluginManager().getPlugin("TerminatorPlus");
+        if (plugin == null) {
+            return defaults();
+        }
+        return new NavigationConfig(
+                bool(plugin, ROOT + "enabled", true),
+                bool(plugin, ROOT + "apply-to-movement-controller-fallback", true),
+                bool(plugin, ROOT + "suppress-legacy-fallback", true),
+                bool(plugin, ROOT + "allow-break-fallback", true),
+                bool(plugin, ROOT + "open-doors", true),
+                bool(plugin, ROOT + "open-trapdoors", true),
+                bool(plugin, ROOT + "open-gates", true),
+                bool(plugin, ROOT + "avoid-hazards", true),
+                integer(plugin, ROOT + "max-nodes", 1800, 128, 10000),
+                integer(plugin, ROOT + "replan-interval-ticks", 8, 1, 80),
+                integer(plugin, ROOT + "target-predict-ticks", 6, 0, 20),
+                integer(plugin, ROOT + "max-drop-blocks", 3, 1, 8),
+                decimal(plugin, ROOT + "max-search-distance", 48.0, 8.0, 160.0),
+                decimal(plugin, ROOT + "goal-radius", 3.3, 1.0, 8.0),
+                decimal(plugin, ROOT + "line-of-sight-goal-radius", 5.5, 1.0, 12.0)
+        );
+    }
+
+    static NavigationConfig defaults() {
+        return new NavigationConfig(true, true, true, true, true, true, true, true,
+                1800, 8, 6, 3, 48.0, 3.3, 5.5);
+    }
+
+    private static boolean bool(Plugin plugin, String path, boolean fallback) {
+        return plugin.getConfig().getBoolean(path, fallback);
+    }
+
+    private static int integer(Plugin plugin, String path, int fallback, int min, int max) {
+        int value = plugin.getConfig().getInt(path, fallback);
+        return Math.max(min, Math.min(max, value));
+    }
+
+    private static double decimal(Plugin plugin, String path, double fallback, double min, double max) {
+        double value = plugin.getConfig().getDouble(path, fallback);
+        if (!Double.isFinite(value)) return fallback;
+        return Math.max(min, Math.min(max, value));
+    }
+}

--- a/TerminatorPlus-API/src/main/java/net/nuggetmc/tplus/api/agent/legacyagent/NavigationController.java
+++ b/TerminatorPlus-API/src/main/java/net/nuggetmc/tplus/api/agent/legacyagent/NavigationController.java
@@ -1,0 +1,258 @@
+package net.nuggetmc.tplus.api.agent.legacyagent;
+
+import net.nuggetmc.tplus.api.Terminator;
+import org.bukkit.Location;
+import org.bukkit.Material;
+import org.bukkit.Sound;
+import org.bukkit.SoundCategory;
+import org.bukkit.World;
+import org.bukkit.block.Block;
+import org.bukkit.block.data.BlockData;
+import org.bukkit.block.data.type.Gate;
+import org.bukkit.block.data.type.TrapDoor;
+import org.bukkit.entity.LivingEntity;
+import org.bukkit.util.Vector;
+
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+
+final class NavigationController {
+    private static final double ARRIVAL_DISTANCE_SQ = 0.42 * 0.42;
+    private static final long PLAN_TTL_NANOS = 300_000_000_000L;
+
+    private final LegacyAgent legacy;
+    private final Map<UUID, ActivePlan> activePlans = new HashMap<>();
+
+    NavigationController(LegacyAgent legacy) {
+        this.legacy = legacy;
+    }
+
+    boolean handlesMovementControllerFallback() {
+        return NavigationConfig.load().applyToMovementControllerFallback();
+    }
+
+    boolean move(
+            Terminator bot,
+            LivingEntity target,
+            Location botLocation,
+            Location targetLocation,
+            LegacyAgent.MovementMode mode,
+            boolean allowMovement
+    ) {
+        NavigationConfig config = NavigationConfig.load();
+        if (!config.enabled() || !allowMovement || bot == null || target == null || !target.isValid()) {
+            return false;
+        }
+        if (mode == LegacyAgent.MovementMode.FULL_REPLACEMENT_NN) {
+            return false;
+        }
+        if (mode == LegacyAgent.MovementMode.MOVEMENT_CONTROLLER_NN && !config.applyToMovementControllerFallback()) {
+            return false;
+        }
+
+        prunePlans();
+        UUID id = bot.getBukkitEntity().getUniqueId();
+        TerrainReader terrain = new TerrainReader(config);
+        TerrainPathfinder pathfinder = new TerrainPathfinder(terrain, config);
+
+        ActivePlan plan = activePlans.get(id);
+        if (shouldReplan(bot, target, terrain, plan, config)) {
+            Optional<NavPath> next = pathfinder.findBestPath(bot, target);
+            plan = next.map(path -> new ActivePlan(path, target.getLocation(), bot.getAliveTicks()))
+                    .orElseGet(() -> ActivePlan.failed(target.getLocation(), bot.getAliveTicks()));
+            activePlans.put(id, plan);
+        }
+        plan.lastTouchNanos = System.nanoTime();
+
+        if (plan.path == null || plan.path.empty()) {
+            if (config.suppressLegacyFallback()) {
+                exploratoryRecovery(bot, target, botLocation);
+                return true;
+            }
+            return false;
+        }
+
+        if (!plan.path.breakEnabled()) {
+            legacy.stopMining(bot);
+        }
+        return followPath(bot, target, terrain, plan);
+    }
+
+    private boolean shouldReplan(
+            Terminator bot,
+            LivingEntity target,
+            TerrainReader terrain,
+            ActivePlan plan,
+            NavigationConfig config
+    ) {
+        if (plan == null || plan.path == null || plan.finished()) return true;
+        if (bot.getAliveTicks() - plan.createdTick >= config.replanIntervalTicks()) return true;
+        if (!sameWorld(plan.targetSnapshot, target.getLocation())) return true;
+        if (plan.targetSnapshot.distanceSquared(target.getLocation()) > 6.25) return true;
+
+        NavStep next = plan.nextStep();
+        if (next == null) return true;
+        World world = bot.getBukkitEntity().getWorld();
+        if (!next.actions().isEmpty()) return false;
+        return !terrain.canOccupyNow(world, next.node());
+    }
+
+    private boolean followPath(Terminator bot, LivingEntity target, TerrainReader terrain, ActivePlan plan) {
+        World world = bot.getBukkitEntity().getWorld();
+        Location loc = bot.getLocation();
+        plan.advancePastReached(loc);
+        if (plan.finished()) {
+            bot.faceLocation(target.getLocation());
+            bot.walk(new Vector(0, 0, 0));
+            return true;
+        }
+
+        NavStep step = plan.nextStep();
+        for (NavAction action : step.actions()) {
+            if (!terrain.actionStillRequired(world, action)) continue;
+            executeAction(bot, target, terrain, world, action, plan.path.breakEnabled());
+            return true;
+        }
+
+        Location waypoint = step.node().center(world);
+        Vector flat = waypoint.toVector().subtract(loc.toVector()).setY(0.0);
+        if (flat.lengthSquared() <= ARRIVAL_DISTANCE_SQ) {
+            plan.index++;
+            return true;
+        }
+
+        Vector direction = flat.clone();
+        if (direction.lengthSquared() > 1.0e-9) {
+            direction.normalize();
+        }
+        double distanceToTarget = loc.distance(target.getLocation());
+        double speed = distanceToTarget > 5.0 ? 0.40 : 0.30;
+        Vector move = direction.multiply(speed);
+
+        boolean ascending = waypoint.getBlockY() > loc.getBlockY();
+        if (bot.tickDelay(4)) {
+            // Face the path while routing around terrain; close to melee, favor target facing.
+            bot.faceLocation(distanceToTarget <= 5.0 ? target.getLocation() : waypoint);
+        }
+        if (!bot.isBotOnGround()) {
+            bot.walk(move);
+            return true;
+        }
+
+        bot.stand();
+        if (ascending) {
+            move.setY(0.42);
+            bot.jump(move);
+        } else {
+            bot.walk(move);
+        }
+        return true;
+    }
+
+    private void executeAction(
+            Terminator bot,
+            LivingEntity target,
+            TerrainReader terrain,
+            World world,
+            NavAction action,
+            boolean breakEnabled
+    ) {
+        Block block = action.block().block(world);
+        bot.faceLocation(action.block().center(world));
+        if (action.type() == NavAction.Type.OPEN) {
+            if (terrain.open(block)) {
+                world.playSound(block.getLocation(), soundForOpen(block), SoundCategory.BLOCKS, 0.8f, 1.0f);
+            }
+            return;
+        }
+        if (action.type() == NavAction.Type.BREAK && breakEnabled) {
+            if (!terrain.canBreak(block.getType())) return;
+            bot.punch();
+            world.playSound(block.getLocation(), LegacyUtils.breakBlockSound(block), SoundCategory.BLOCKS, 0.7f, 1.0f);
+            block.breakNaturally();
+        }
+    }
+
+    private static Sound soundForOpen(Block block) {
+        BlockData data = block.getBlockData();
+        if (data instanceof Gate) return Sound.BLOCK_FENCE_GATE_OPEN;
+        if (data instanceof TrapDoor) return Sound.BLOCK_WOODEN_TRAPDOOR_OPEN;
+        return Sound.BLOCK_WOODEN_DOOR_OPEN;
+    }
+
+    private void exploratoryRecovery(Terminator bot, LivingEntity target, Location botLocation) {
+        legacy.stopMining(bot);
+        Vector toTarget = target.getLocation().toVector().subtract(botLocation.toVector()).setY(0.0);
+        if (toTarget.lengthSquared() < 1.0e-9) {
+            toTarget = botLocation.getDirection().setY(0.0);
+        }
+        if (toTarget.lengthSquared() < 1.0e-9) {
+            toTarget = new Vector(1, 0, 0);
+        }
+        toTarget.normalize();
+        double side = bot.tickDelay(20) ? 1.0 : -1.0;
+        Vector sidestep = new Vector(-toTarget.getZ(), 0, toTarget.getX()).multiply(0.32 * side);
+        Vector forward = toTarget.multiply(0.12);
+        Vector move = forward.add(sidestep);
+        bot.faceLocation(target.getLocation());
+        if (bot.isBotOnGround()) {
+            move.setY(0.42);
+            bot.jump(move);
+        } else {
+            move.setY(0.0);
+            bot.walk(move);
+        }
+    }
+
+    private static boolean sameWorld(Location a, Location b) {
+        return a != null && b != null && a.getWorld() == b.getWorld();
+    }
+
+    private void prunePlans() {
+        long now = System.nanoTime();
+        Iterator<Map.Entry<UUID, ActivePlan>> iterator = activePlans.entrySet().iterator();
+        while (iterator.hasNext()) {
+            if (now - iterator.next().getValue().lastTouchNanos > PLAN_TTL_NANOS) {
+                iterator.remove();
+            }
+        }
+    }
+
+    private static final class ActivePlan {
+        final NavPath path;
+        final Location targetSnapshot;
+        final int createdTick;
+        int index;
+        long lastTouchNanos;
+
+        ActivePlan(NavPath path, Location targetSnapshot, int createdTick) {
+            this.path = path;
+            this.targetSnapshot = targetSnapshot.clone();
+            this.createdTick = createdTick;
+            this.index = path.steps().size() > 1 ? 1 : 0;
+            this.lastTouchNanos = System.nanoTime();
+        }
+
+        static ActivePlan failed(Location targetSnapshot, int createdTick) {
+            return new ActivePlan(new NavPath(TerrainPathfinder.SearchMode.NO_BREAK, java.util.List.of(), 0, "failed"),
+                    targetSnapshot, createdTick);
+        }
+
+        boolean finished() {
+            return index >= path.steps().size();
+        }
+
+        NavStep nextStep() {
+            return finished() ? null : path.steps().get(index);
+        }
+
+        void advancePastReached(Location loc) {
+            while (!finished() && nextStep().node().distanceSquared(loc) <= ARRIVAL_DISTANCE_SQ) {
+                index++;
+            }
+        }
+    }
+}

--- a/TerminatorPlus-API/src/main/java/net/nuggetmc/tplus/api/agent/legacyagent/NavigationController.java
+++ b/TerminatorPlus-API/src/main/java/net/nuggetmc/tplus/api/agent/legacyagent/NavigationController.java
@@ -2,7 +2,6 @@ package net.nuggetmc.tplus.api.agent.legacyagent;
 
 import net.nuggetmc.tplus.api.Terminator;
 import org.bukkit.Location;
-import org.bukkit.Material;
 import org.bukkit.Sound;
 import org.bukkit.SoundCategory;
 import org.bukkit.World;
@@ -34,24 +33,12 @@ final class NavigationController {
         return NavigationConfig.load().applyToMovementControllerFallback();
     }
 
-    boolean move(
-            Terminator bot,
-            LivingEntity target,
-            Location botLocation,
-            Location targetLocation,
-            LegacyAgent.MovementMode mode,
-            boolean allowMovement
-    ) {
+    boolean move(Terminator bot, LivingEntity target, Location botLocation, Location targetLocation,
+                 LegacyAgent.MovementMode mode, boolean allowMovement) {
         NavigationConfig config = NavigationConfig.load();
-        if (!config.enabled() || !allowMovement || bot == null || target == null || !target.isValid()) {
-            return false;
-        }
-        if (mode == LegacyAgent.MovementMode.FULL_REPLACEMENT_NN) {
-            return false;
-        }
-        if (mode == LegacyAgent.MovementMode.MOVEMENT_CONTROLLER_NN && !config.applyToMovementControllerFallback()) {
-            return false;
-        }
+        if (!config.enabled() || !allowMovement || bot == null || target == null || !target.isValid()) return false;
+        if (mode == LegacyAgent.MovementMode.FULL_REPLACEMENT_NN) return false;
+        if (mode == LegacyAgent.MovementMode.MOVEMENT_CONTROLLER_NN && !config.applyToMovementControllerFallback()) return false;
 
         prunePlans();
         UUID id = bot.getBukkitEntity().getUniqueId();
@@ -75,23 +62,18 @@ final class NavigationController {
             return false;
         }
 
-        if (!plan.path.breakEnabled()) {
-            legacy.stopMining(bot);
-        }
+        if (!plan.path.breakEnabled()) legacy.stopMining(bot);
         return followPath(bot, target, terrain, plan);
     }
 
-    private boolean shouldReplan(
-            Terminator bot,
-            LivingEntity target,
-            TerrainReader terrain,
-            ActivePlan plan,
-            NavigationConfig config
-    ) {
-        if (plan == null || plan.path == null || plan.finished()) return true;
-        if (bot.getAliveTicks() - plan.createdTick >= config.replanIntervalTicks()) return true;
+    private boolean shouldReplan(Terminator bot, LivingEntity target, TerrainReader terrain,
+                                 ActivePlan plan, NavigationConfig config) {
+        if (plan == null || plan.path == null) return true;
         if (!sameWorld(plan.targetSnapshot, target.getLocation())) return true;
         if (plan.targetSnapshot.distanceSquared(target.getLocation()) > 6.25) return true;
+        if (bot.getAliveTicks() - plan.createdTick >= config.replanIntervalTicks()) return true;
+        if (plan.path.empty()) return false;
+        if (plan.finished()) return true;
 
         NavStep next = plan.nextStep();
         if (next == null) return true;
@@ -113,7 +95,7 @@ final class NavigationController {
         NavStep step = plan.nextStep();
         for (NavAction action : step.actions()) {
             if (!terrain.actionStillRequired(world, action)) continue;
-            executeAction(bot, target, terrain, world, action, plan.path.breakEnabled());
+            executeAction(bot, terrain, world, action, plan.path.breakEnabled());
             return true;
         }
 
@@ -125,18 +107,13 @@ final class NavigationController {
         }
 
         Vector direction = flat.clone();
-        if (direction.lengthSquared() > 1.0e-9) {
-            direction.normalize();
-        }
+        if (direction.lengthSquared() > 1.0e-9) direction.normalize();
         double distanceToTarget = loc.distance(target.getLocation());
         double speed = distanceToTarget > 5.0 ? 0.40 : 0.30;
         Vector move = direction.multiply(speed);
-
         boolean ascending = waypoint.getBlockY() > loc.getBlockY();
-        if (bot.tickDelay(4)) {
-            // Face the path while routing around terrain; close to melee, favor target facing.
-            bot.faceLocation(distanceToTarget <= 5.0 ? target.getLocation() : waypoint);
-        }
+
+        if (bot.tickDelay(4)) bot.faceLocation(distanceToTarget <= 5.0 ? target.getLocation() : waypoint);
         if (!bot.isBotOnGround()) {
             bot.walk(move);
             return true;
@@ -152,26 +129,18 @@ final class NavigationController {
         return true;
     }
 
-    private void executeAction(
-            Terminator bot,
-            LivingEntity target,
-            TerrainReader terrain,
-            World world,
-            NavAction action,
-            boolean breakEnabled
-    ) {
+    private void executeAction(Terminator bot, TerrainReader terrain, World world, NavAction action, boolean breakEnabled) {
         Block block = action.block().block(world);
         bot.faceLocation(action.block().center(world));
         if (action.type() == NavAction.Type.OPEN) {
-            if (terrain.open(block)) {
-                world.playSound(block.getLocation(), soundForOpen(block), SoundCategory.BLOCKS, 0.8f, 1.0f);
-            }
+            if (terrain.open(block)) world.playSound(block.getLocation(), soundForOpen(block), SoundCategory.BLOCKS, 0.8f, 1.0f);
             return;
         }
         if (action.type() == NavAction.Type.BREAK && breakEnabled) {
             if (!terrain.canBreak(block.getType())) return;
             bot.punch();
-            world.playSound(block.getLocation(), LegacyUtils.breakBlockSound(block), SoundCategory.BLOCKS, 0.7f, 1.0f);
+            Sound sound = LegacyUtils.breakBlockSound(block);
+            if (sound != null) world.playSound(block.getLocation(), sound, SoundCategory.BLOCKS, 0.7f, 1.0f);
             block.breakNaturally();
         }
     }
@@ -186,12 +155,8 @@ final class NavigationController {
     private void exploratoryRecovery(Terminator bot, LivingEntity target, Location botLocation) {
         legacy.stopMining(bot);
         Vector toTarget = target.getLocation().toVector().subtract(botLocation.toVector()).setY(0.0);
-        if (toTarget.lengthSquared() < 1.0e-9) {
-            toTarget = botLocation.getDirection().setY(0.0);
-        }
-        if (toTarget.lengthSquared() < 1.0e-9) {
-            toTarget = new Vector(1, 0, 0);
-        }
+        if (toTarget.lengthSquared() < 1.0e-9) toTarget = botLocation.getDirection().setY(0.0);
+        if (toTarget.lengthSquared() < 1.0e-9) toTarget = new Vector(1, 0, 0);
         toTarget.normalize();
         double side = bot.tickDelay(20) ? 1.0 : -1.0;
         Vector sidestep = new Vector(-toTarget.getZ(), 0, toTarget.getX()).multiply(0.32 * side);
@@ -215,9 +180,7 @@ final class NavigationController {
         long now = System.nanoTime();
         Iterator<Map.Entry<UUID, ActivePlan>> iterator = activePlans.entrySet().iterator();
         while (iterator.hasNext()) {
-            if (now - iterator.next().getValue().lastTouchNanos > PLAN_TTL_NANOS) {
-                iterator.remove();
-            }
+            if (now - iterator.next().getValue().lastTouchNanos > PLAN_TTL_NANOS) iterator.remove();
         }
     }
 
@@ -237,8 +200,7 @@ final class NavigationController {
         }
 
         static ActivePlan failed(Location targetSnapshot, int createdTick) {
-            return new ActivePlan(new NavPath(TerrainPathfinder.SearchMode.NO_BREAK, java.util.List.of(), 0, "failed"),
-                    targetSnapshot, createdTick);
+            return new ActivePlan(new NavPath(TerrainPathfinder.SearchMode.NO_BREAK, java.util.List.of(), 0, "failed"), targetSnapshot, createdTick);
         }
 
         boolean finished() {
@@ -250,9 +212,7 @@ final class NavigationController {
         }
 
         void advancePastReached(Location loc) {
-            while (!finished() && nextStep().node().distanceSquared(loc) <= ARRIVAL_DISTANCE_SQ) {
-                index++;
-            }
+            while (!finished() && nextStep().node().distanceSquared(loc) <= ARRIVAL_DISTANCE_SQ) index++;
         }
     }
 }

--- a/TerminatorPlus-API/src/main/java/net/nuggetmc/tplus/api/agent/legacyagent/TerrainPathfinder.java
+++ b/TerminatorPlus-API/src/main/java/net/nuggetmc/tplus/api/agent/legacyagent/TerrainPathfinder.java
@@ -9,7 +9,6 @@ import org.bukkit.util.Vector;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.HashMap;
-import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -32,7 +31,7 @@ final class TerrainPathfinder {
     Optional<NavPath> findBestPath(Terminator bot, LivingEntity target) {
         World world = bot.getBukkitEntity().getWorld();
         NavNode start = NavNode.from(bot.getLocation());
-        GoalRegion goal = GoalRegion.from(bot, target, config);
+        GoalRegion goal = GoalRegion.from(target, config);
 
         Optional<NavPath> noBreak = search(world, start, goal, SearchMode.NO_BREAK);
         if (noBreak.isPresent()) return noBreak;
@@ -182,18 +181,14 @@ final class TerrainPathfinder {
     }
 
     private record GoalRegion(Location target, Location predictedTarget, double radius, double losRadius) {
-        static GoalRegion from(Terminator bot, LivingEntity target, NavigationConfig config) {
+        static GoalRegion from(LivingEntity target, NavigationConfig config) {
             Location current = target.getLocation();
             Location predicted = current.clone();
             Vector velocity = target.getVelocity().clone().setY(0);
+            velocity.multiply(config.targetPredictTicks());
             double maxLead = 4.0;
             if (velocity.lengthSquared() > maxLead * maxLead) {
                 velocity.normalize().multiply(maxLead);
-            } else {
-                velocity.multiply(config.targetPredictTicks());
-                if (velocity.lengthSquared() > maxLead * maxLead) {
-                    velocity.normalize().multiply(maxLead);
-                }
             }
             predicted.add(velocity);
             predicted.setY(current.getY());
@@ -204,11 +199,12 @@ final class TerrainPathfinder {
             if (!terrain.canOccupyNow(world, node)) return false;
             Location feet = node.center(world);
             double distanceSq = feet.distanceSquared(target);
-            if (distanceSq <= radius * radius) return true;
-            if (distanceSq > losRadius * losRadius) return false;
+            double maxGoal = Math.max(radius, losRadius);
+            if (distanceSq > maxGoal * maxGoal) return false;
 
             Location eye = feet.clone().add(0.0, 1.62, 0.0);
-            return LegacyUtils.checkFreeSpace(eye, target.clone().add(0.0, 1.0, 0.0));
+            Location targetEye = target.clone().add(0.0, 1.0, 0.0);
+            return LegacyUtils.checkFreeSpace(eye, targetEye);
         }
     }
 }

--- a/TerminatorPlus-API/src/main/java/net/nuggetmc/tplus/api/agent/legacyagent/TerrainPathfinder.java
+++ b/TerminatorPlus-API/src/main/java/net/nuggetmc/tplus/api/agent/legacyagent/TerrainPathfinder.java
@@ -1,0 +1,214 @@
+package net.nuggetmc.tplus.api.agent.legacyagent;
+
+import net.nuggetmc.tplus.api.Terminator;
+import org.bukkit.Location;
+import org.bukkit.World;
+import org.bukkit.entity.LivingEntity;
+import org.bukkit.util.Vector;
+
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.PriorityQueue;
+
+final class TerrainPathfinder {
+    private static final int[][] CARDINAL_AND_DIAGONAL = {
+            {1, 0}, {-1, 0}, {0, 1}, {0, -1},
+            {1, 1}, {1, -1}, {-1, 1}, {-1, -1}
+    };
+
+    private final TerrainReader terrain;
+    private final NavigationConfig config;
+
+    TerrainPathfinder(TerrainReader terrain, NavigationConfig config) {
+        this.terrain = terrain;
+        this.config = config;
+    }
+
+    Optional<NavPath> findBestPath(Terminator bot, LivingEntity target) {
+        World world = bot.getBukkitEntity().getWorld();
+        NavNode start = NavNode.from(bot.getLocation());
+        GoalRegion goal = GoalRegion.from(bot, target, config);
+
+        Optional<NavPath> noBreak = search(world, start, goal, SearchMode.NO_BREAK);
+        if (noBreak.isPresent()) return noBreak;
+        if (!config.allowBreakFallback()) return Optional.empty();
+        return search(world, start, goal, SearchMode.ALLOW_BREAK);
+    }
+
+    private Optional<NavPath> search(World world, NavNode start, GoalRegion goal, SearchMode mode) {
+        PriorityQueue<SearchNode> open = new PriorityQueue<>(Comparator.comparingDouble(SearchNode::estimatedTotal));
+        Map<NavNode, SearchNode> best = new HashMap<>();
+        SearchNode root = new SearchNode(start, null, null, 0.0, heuristic(start, goal), 0);
+        open.add(root);
+        best.put(start, root);
+
+        int considered = 0;
+        while (!open.isEmpty() && considered < config.maxNodes()) {
+            SearchNode current = open.poll();
+            SearchNode bestKnown = best.get(current.node());
+            if (bestKnown != current) continue;
+            considered++;
+
+            if (goal.satisfiedBy(world, terrain, current.node())) {
+                return Optional.of(reconstruct(current, mode, considered, "goal"));
+            }
+
+            for (Edge edge : neighbors(world, current.node(), start, goal, mode)) {
+                double nextCost = current.cost() + edge.cost();
+                SearchNode previous = best.get(edge.to());
+                if (previous != null && previous.cost() <= nextCost) continue;
+                SearchNode next = new SearchNode(edge.to(), current, edge.step(), nextCost,
+                        nextCost + heuristic(edge.to(), goal), current.depth() + 1);
+                best.put(edge.to(), next);
+                open.add(next);
+            }
+        }
+        return Optional.empty();
+    }
+
+    private List<Edge> neighbors(World world, NavNode node, NavNode start, GoalRegion goal, SearchMode mode) {
+        List<Edge> out = new ArrayList<>();
+        for (int[] dir : CARDINAL_AND_DIAGONAL) {
+            int dx = dir[0];
+            int dz = dir[1];
+            addCandidate(world, out, node, start, goal, mode, dx, 0, dz, "walk");
+            addCandidate(world, out, node, start, goal, mode, dx, 1, dz, "ascend");
+            addCandidate(world, out, node, start, goal, mode, dx, -1, dz, "descend");
+            for (int drop = 2; drop <= config.maxDropBlocks(); drop++) {
+                addCandidate(world, out, node, start, goal, mode, dx, -drop, dz, "drop" + drop);
+            }
+        }
+        return out;
+    }
+
+    private void addCandidate(
+            World world,
+            List<Edge> out,
+            NavNode from,
+            NavNode start,
+            GoalRegion goal,
+            SearchMode mode,
+            int dx,
+            int dy,
+            int dz,
+            String moveType
+    ) {
+        NavNode to = new NavNode(from.x() + dx, from.y() + dy, from.z() + dz);
+        if (!withinBounds(to, start, goal)) return;
+        if (dy > 1 || dy < -config.maxDropBlocks()) return;
+        if (dx != 0 && dz != 0 && !diagonalAllowed(world, from, dx, dz, mode)) return;
+
+        TerrainReader.TraversalPlan plan = terrain.planOccupy(world, to, mode);
+        if (!plan.passable()) return;
+
+        double horizontal = dx != 0 && dz != 0 ? 1.414 : 1.0;
+        double vertical = dy > 0 ? 1.6 * dy : dy < 0 ? 0.4 * -dy : 0.0;
+        double modePenalty = mode == SearchMode.ALLOW_BREAK && !plan.actions().isEmpty() ? 20.0 : 0.0;
+        double cost = horizontal + vertical + plan.extraCost() + modePenalty;
+        out.add(new Edge(to, new NavStep(to, plan.actions(), moveType, cost), cost));
+    }
+
+    private boolean diagonalAllowed(World world, NavNode from, int dx, int dz, SearchMode mode) {
+        NavNode sideA = new NavNode(from.x() + dx, from.y(), from.z());
+        NavNode sideB = new NavNode(from.x(), from.y(), from.z() + dz);
+        // Do not clip through a corner. In break mode this still permits planned
+        // diagonal movement if one side is openable/breakable, but never through two
+        // fully blocked sides.
+        return terrain.planOccupy(world, sideA, mode).passable()
+                || terrain.planOccupy(world, sideB, mode).passable();
+    }
+
+    private boolean withinBounds(NavNode node, NavNode start, GoalRegion goal) {
+        double max = config.maxSearchDistance();
+        double sx = node.x() - start.x();
+        double sy = node.y() - start.y();
+        double sz = node.z() - start.z();
+        if (sx * sx + sy * sy + sz * sz > max * max) return false;
+
+        Location predicted = goal.predictedTarget();
+        double gx = node.x() + 0.5 - predicted.getX();
+        double gy = node.y() - predicted.getY();
+        double gz = node.z() + 0.5 - predicted.getZ();
+        return gx * gx + gy * gy + gz * gz <= (max + goal.radius()) * (max + goal.radius());
+    }
+
+    private static double heuristic(NavNode node, GoalRegion goal) {
+        Location target = goal.predictedTarget();
+        double dx = node.x() + 0.5 - target.getX();
+        double dz = node.z() + 0.5 - target.getZ();
+        double dy = Math.abs(node.y() - target.getY());
+        return Math.sqrt(dx * dx + dz * dz) + dy * 1.4;
+    }
+
+    private static NavPath reconstruct(SearchNode end, SearchMode mode, int considered, String reason) {
+        List<NavStep> reversed = new ArrayList<>();
+        SearchNode current = end;
+        while (current != null) {
+            if (current.stepFromParent() == null) {
+                reversed.add(new NavStep(current.node(), List.of(), "start", 0.0));
+            } else {
+                reversed.add(current.stepFromParent());
+            }
+            current = current.parent();
+        }
+        List<NavStep> steps = new ArrayList<>(reversed.size());
+        for (int i = reversed.size() - 1; i >= 0; i--) {
+            steps.add(reversed.get(i));
+        }
+        return new NavPath(mode, steps, considered, reason);
+    }
+
+    enum SearchMode {
+        NO_BREAK,
+        ALLOW_BREAK
+    }
+
+    private record Edge(NavNode to, NavStep step, double cost) {
+    }
+
+    private record SearchNode(
+            NavNode node,
+            SearchNode parent,
+            NavStep stepFromParent,
+            double cost,
+            double estimatedTotal,
+            int depth
+    ) {
+    }
+
+    private record GoalRegion(Location target, Location predictedTarget, double radius, double losRadius) {
+        static GoalRegion from(Terminator bot, LivingEntity target, NavigationConfig config) {
+            Location current = target.getLocation();
+            Location predicted = current.clone();
+            Vector velocity = target.getVelocity().clone().setY(0);
+            double maxLead = 4.0;
+            if (velocity.lengthSquared() > maxLead * maxLead) {
+                velocity.normalize().multiply(maxLead);
+            } else {
+                velocity.multiply(config.targetPredictTicks());
+                if (velocity.lengthSquared() > maxLead * maxLead) {
+                    velocity.normalize().multiply(maxLead);
+                }
+            }
+            predicted.add(velocity);
+            predicted.setY(current.getY());
+            return new GoalRegion(current, predicted, config.goalRadius(), config.lineOfSightGoalRadius());
+        }
+
+        boolean satisfiedBy(World world, TerrainReader terrain, NavNode node) {
+            if (!terrain.canOccupyNow(world, node)) return false;
+            Location feet = node.center(world);
+            double distanceSq = feet.distanceSquared(target);
+            if (distanceSq <= radius * radius) return true;
+            if (distanceSq > losRadius * losRadius) return false;
+
+            Location eye = feet.clone().add(0.0, 1.62, 0.0);
+            return LegacyUtils.checkFreeSpace(eye, target.clone().add(0.0, 1.0, 0.0));
+        }
+    }
+}

--- a/TerminatorPlus-API/src/main/java/net/nuggetmc/tplus/api/agent/legacyagent/TerrainReader.java
+++ b/TerminatorPlus-API/src/main/java/net/nuggetmc/tplus/api/agent/legacyagent/TerrainReader.java
@@ -1,0 +1,208 @@
+package net.nuggetmc.tplus.api.agent.legacyagent;
+
+import org.bukkit.Material;
+import org.bukkit.World;
+import org.bukkit.block.Block;
+import org.bukkit.block.BlockFace;
+import org.bukkit.block.data.BlockData;
+import org.bukkit.block.data.Openable;
+import org.bukkit.block.data.type.Door;
+import org.bukkit.block.data.type.Gate;
+import org.bukkit.block.data.type.TrapDoor;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+final class TerrainReader {
+    private final NavigationConfig config;
+
+    TerrainReader(NavigationConfig config) {
+        this.config = config;
+    }
+
+    TraversalPlan planOccupy(World world, NavNode node, TerrainPathfinder.SearchMode mode) {
+        Block feet = world.getBlockAt(node.x(), node.y(), node.z());
+        Block head = world.getBlockAt(node.x(), node.y() + 1, node.z());
+        Block below = world.getBlockAt(node.x(), node.y() - 1, node.z());
+
+        if (!canStandOn(below)) {
+            return TraversalPlan.blocked("no-floor");
+        }
+
+        Clearance feetClearance = clearance(feet, mode, "feet");
+        if (!feetClearance.passable()) {
+            return TraversalPlan.blocked(feetClearance.reason());
+        }
+        Clearance headClearance = clearance(head, mode, "head");
+        if (!headClearance.passable()) {
+            return TraversalPlan.blocked(headClearance.reason());
+        }
+
+        Map<BlockKey, NavAction> deduped = new LinkedHashMap<>();
+        feetClearance.actions().forEach(action -> deduped.put(action.block(), action));
+        headClearance.actions().forEach(action -> deduped.put(action.block(), action));
+        return TraversalPlan.passable(new ArrayList<>(deduped.values()), feetClearance.cost() + headClearance.cost());
+    }
+
+    boolean canOccupyNow(World world, NavNode node) {
+        return planOccupy(world, node, TerrainPathfinder.SearchMode.NO_BREAK).passable();
+    }
+
+    boolean actionStillRequired(World world, NavAction action) {
+        Block block = action.block().block(world);
+        if (action.type() == NavAction.Type.OPEN) {
+            BlockData data = block.getBlockData();
+            return data instanceof Openable openable && !openable.isOpen();
+        }
+        if (action.type() == NavAction.Type.BREAK) {
+            return !isPassThrough(block) && canBreak(block.getType());
+        }
+        return false;
+    }
+
+    boolean open(Block block) {
+        BlockData data = block.getBlockData();
+        if (!(data instanceof Openable openable)) return false;
+        if (openable.isOpen()) return false;
+        openable.setOpen(true);
+        block.setBlockData(data, true);
+        syncDoorHalf(block, data);
+        return true;
+    }
+
+    private static void syncDoorHalf(Block block, BlockData data) {
+        if (!(data instanceof Door door)) return;
+        Block other = door.getHalf() == org.bukkit.block.data.Bisected.Half.TOP
+                ? block.getRelative(BlockFace.DOWN)
+                : block.getRelative(BlockFace.UP);
+        BlockData otherData = other.getBlockData();
+        if (otherData instanceof Door otherDoor) {
+            otherDoor.setOpen(true);
+            other.setBlockData(otherData, true);
+        }
+    }
+
+    private Clearance clearance(Block block, TerrainPathfinder.SearchMode mode, String slot) {
+        if (isHazard(block)) {
+            return Clearance.blocked("hazard-" + block.getType().name().toLowerCase(java.util.Locale.ROOT));
+        }
+        if (isPassThrough(block)) {
+            return Clearance.passable(List.of(), passThroughCost(block));
+        }
+        if (isOpenable(block) && canOpen(block)) {
+            return Clearance.passable(List.of(new NavAction(NavAction.Type.OPEN, BlockKey.of(block), "open-" + slot)), 1.2);
+        }
+        if (mode == TerrainPathfinder.SearchMode.ALLOW_BREAK && canBreak(block.getType())) {
+            return Clearance.passable(List.of(new NavAction(NavAction.Type.BREAK, BlockKey.of(block), "break-" + slot)), breakCost(block.getType()));
+        }
+        return Clearance.blocked("blocked-" + block.getType().name().toLowerCase(java.util.Locale.ROOT));
+    }
+
+    private boolean canOpen(Block block) {
+        BlockData data = block.getBlockData();
+        if (data instanceof Door) return config.allowDoors();
+        if (data instanceof TrapDoor) return config.allowTrapdoors();
+        if (data instanceof Gate) return config.allowGates();
+        return false;
+    }
+
+    private boolean isOpenable(Block block) {
+        return block.getBlockData() instanceof Openable;
+    }
+
+    boolean isHazard(Block block) {
+        if (!config.avoidHazards()) return false;
+        Material type = block.getType();
+        return type == Material.LAVA
+                || type == Material.FIRE
+                || type == Material.SOUL_FIRE
+                || type == Material.CACTUS
+                || type == Material.MAGMA_BLOCK
+                || type == Material.SWEET_BERRY_BUSH
+                || type == Material.POWDER_SNOW
+                || type.name().endsWith("_CAMPFIRE");
+    }
+
+    boolean isPassThrough(Block block) {
+        Material type = block.getType();
+        if (type == Material.LAVA) return false;
+        if (LegacyMats.BREAK.contains(type)) return true;
+        if (block.getBlockData() instanceof Openable openable) {
+            return openable.isOpen();
+        }
+        if (LegacyMats.FENCE.contains(type) || LegacyMats.GATES.contains(type) || LegacyMats.OBSTACLES.contains(type)) {
+            return false;
+        }
+        return !type.isSolid() && !LegacyMats.canStandOn(type);
+    }
+
+    boolean canStandOn(Block block) {
+        if (isHazard(block)) return false;
+        Material type = block.getType();
+        if (type == Material.WATER || type == Material.LAVA) return false;
+        if (block.getBlockData() instanceof Openable openable && openable.isOpen()) return false;
+        return type.isSolid() || LegacyMats.canStandOn(type);
+    }
+
+    boolean canBreak(Material type) {
+        if (type == null || LegacyMats.BREAK.contains(type)) return false;
+        return type != Material.BEDROCK
+                && type != Material.BARRIER
+                && type != Material.END_PORTAL_FRAME
+                && type != Material.STRUCTURE_BLOCK
+                && type != Material.COMMAND_BLOCK
+                && type != Material.REPEATING_COMMAND_BLOCK
+                && type != Material.CHAIN_COMMAND_BLOCK;
+    }
+
+    double breakCost(Material type) {
+        String name = type.name();
+        if (LegacyMats.INSTANT_BREAK.contains(type)) return 8.0;
+        if (name.contains("OBSIDIAN")) return 900.0;
+        if (name.contains("DEEPSLATE")) return 180.0;
+        if (name.contains("STONE") || name.contains("COBBLE") || name.contains("BRICK")) return 120.0;
+        if (name.contains("DIRT") || name.contains("GRASS") || name.contains("SAND") || name.contains("GRAVEL")) return 55.0;
+        if (name.contains("LOG") || name.contains("PLANK") || name.contains("WOOD") || name.contains("STEM")) return 75.0;
+        if (name.contains("WOOL") || name.contains("LEAVES")) return 35.0;
+        return type.isSolid() ? 90.0 : 25.0;
+    }
+
+    private double passThroughCost(Block block) {
+        Material type = block.getType();
+        if (type == Material.WATER) return 3.0;
+        if (type == Material.COBWEB) return 12.0;
+        return 0.0;
+    }
+
+    record TraversalPlan(boolean passable, List<NavAction> actions, double extraCost, String reason) {
+        TraversalPlan {
+            actions = actions == null ? List.of() : List.copyOf(actions);
+            reason = reason == null ? "" : reason;
+        }
+
+        static TraversalPlan passable(List<NavAction> actions, double extraCost) {
+            return new TraversalPlan(true, actions, extraCost, "");
+        }
+
+        static TraversalPlan blocked(String reason) {
+            return new TraversalPlan(false, List.of(), 0.0, reason);
+        }
+    }
+
+    private record Clearance(boolean passable, List<NavAction> actions, double cost, String reason) {
+        Clearance {
+            actions = actions == null ? List.of() : List.copyOf(actions);
+            reason = reason == null ? "" : reason;
+        }
+
+        static Clearance passable(List<NavAction> actions, double cost) {
+            return new Clearance(true, actions, cost, "");
+        }
+
+        static Clearance blocked(String reason) {
+            return new Clearance(false, List.of(), 0.0, reason);
+        }
+    }
+}

--- a/docs/NAVIGATION_PATHFINDING.md
+++ b/docs/NAVIGATION_PATHFINDING.md
@@ -1,0 +1,106 @@
+# Terrain Navigation Baseline
+
+This branch replaces the old direct-vector legacy chase fallback with a terrain-aware navigator.
+
+## Problem
+
+The previous non-NN baseline moved directly toward the target. It did not know whether the target was behind a wall, over a hill, behind a door, or inside a box. Local obstruction checks then reacted to the block in front of the bot and started mining, which produced bad behavior:
+
+- running into small walls before deciding what to do;
+- trying to match the target's Y level instead of finding a climbable route;
+- mining through hills that could be scaled;
+- breaking doors/trapdoors/gates instead of using them;
+- mining as a first reaction rather than as a planned last resort.
+
+## New model
+
+Navigation is now route-selected instead of obstruction-selected.
+
+```text
+movement request
+  -> no-break A* search
+       walk / diagonal / ascend / descend / safe drop / open doors / open trapdoors / open gates
+  -> if no no-break path exists, optional break-enabled A* search
+       same movement primitives + planned breach blocks
+  -> path follower emits bot.walk(...), bot.jump(...), faceLocation(...)
+```
+
+The important rule is structural: mining is not present in the first search pass. A wall or hill will only be mined if the no-break route cannot reach a line-of-sight combat goal near the target.
+
+## Integration
+
+`LegacyMovementStrategy` now routes movement as follows:
+
+1. Full-replacement NN keeps its previous behavior.
+2. Movement-controller NN gets the first movement attempt.
+3. If the movement-controller cannot move, the terrain navigator replaces the old legacy direct-vector fallback.
+4. Plain legacy mode uses the terrain navigator first.
+5. The old legacy movement path remains as an emergency fallback when navigation is disabled or explicitly configured to allow fallback.
+
+## Goal semantics
+
+The search does not path to the target's exact moving block. It predicts target motion for a small number of ticks and searches for a standable node near the target that has line of sight. This prevents the boxed-target bug where standing outside the wall is incorrectly considered “close enough.”
+
+## Movement primitives
+
+The first pass supports:
+
+- cardinal walking;
+- diagonal walking with corner-clipping prevention;
+- one-block ascent for hills/stairs-like terrain;
+- descent and bounded safe drops;
+- door opening;
+- trapdoor opening;
+- fence-gate opening;
+- hazard avoidance.
+
+The second pass adds:
+
+- planned block breach for feet/head clearance;
+- high cost for hard materials;
+- practical forbids for bedrock, barriers, command blocks, structure blocks, and portal frames.
+
+## Config
+
+```yaml
+ai:
+  navigation:
+    enabled: true
+    apply-to-movement-controller-fallback: true
+    suppress-legacy-fallback: true
+    allow-break-fallback: true
+    open-doors: true
+    open-trapdoors: true
+    open-gates: true
+    avoid-hazards: true
+    max-nodes: 1800
+    replan-interval-ticks: 8
+    target-predict-ticks: 6
+    max-drop-blocks: 3
+    max-search-distance: 48.0
+    goal-radius: 3.3
+    line-of-sight-goal-radius: 5.5
+```
+
+`allow-break-fallback` controls whether mining can ever appear in the route. `suppress-legacy-fallback` prevents the old local obstruction-mining code from taking over when no route is found.
+
+## Expected behavior
+
+| Scenario | Expected behavior |
+| --- | --- |
+| 3x3 wall between bot and target | Route around the wall if reachable. |
+| Target above a hillside | Ascend the terrain instead of mining through the hill. |
+| Closed wooden door | Open and continue. |
+| Closed trapdoor/gate | Open and continue if the clearance path needs it. |
+| Target inside a sealed box | No-break path fails; break-enabled path selects the cheapest breach. |
+| Lava/fire/magma/powder snow in route | Avoid during search when hazard avoidance is enabled. |
+
+## Follow-up work
+
+This PR establishes the baseline. Future improvements should focus on:
+
+- non-instant planned mining animation using the existing crack packet pipeline;
+- jump-gap and parkour timing primitives;
+- smarter stair/slab collision modeling;
+- telemetry for selected path mode and breached blocks;
+- arena tests that assert no-break routes are preferred over mining.

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -18,6 +18,29 @@ ai:
       quarantine-bad-files: true
       legacy-import-behavior: import-compatible-or-reset
       debug-logging: false
+  navigation:
+    # Terrain-aware legacy baseline. The navigator searches for a no-break route
+    # first, then only allows planned mining if no walk/climb/openable route can
+    # satisfy the target goal.
+    enabled: true
+    # Movement-controller NN still gets the first move attempt. If it cannot
+    # produce movement, this navigator replaces the old direct legacy fallback.
+    apply-to-movement-controller-fallback: true
+    # When no route can be found, do not fall back to the old local obstruction
+    # mining logic. The bot will use exploratory recovery instead.
+    suppress-legacy-fallback: true
+    allow-break-fallback: true
+    open-doors: true
+    open-trapdoors: true
+    open-gates: true
+    avoid-hazards: true
+    max-nodes: 1800
+    replan-interval-ticks: 8
+    target-predict-ticks: 6
+    max-drop-blocks: 3
+    max-search-distance: 48.0
+    goal-radius: 3.3
+    line-of-sight-goal-radius: 5.5
   training:
     # Per-generation reinforcement round cap in minutes. Set 0 for unlimited.
     max-round-minutes: 1


### PR DESCRIPTION
## Summary

This PR replaces the old direct-vector legacy movement fallback with a terrain-aware navigation baseline. The goal is to stop bots from treating every obstruction as something to mine and instead make them search for an actual terrain route first.

The new behavior is intentionally two-pass:

1. **No-break path first**
   - walk/cardinal movement
   - diagonal movement with corner clipping prevention
   - one-block ascent for hills
   - descent / bounded safe drops
   - open doors
   - open trapdoors
   - open fence gates
   - avoid hazards

2. **Break-enabled path only if no no-break route exists**
   - planned feet/head clearance breach actions
   - very high costs for hard materials
   - forbids bedrock/barriers/command blocks/structure blocks/end portal frames

This means a wall or hill should be routed around or climbed before any mining is considered. Mining is now route-selected instead of local-obstruction-selected.

## Root cause

The legacy non-NN movement path computes a direct vector to the target and then relies on local block checks when the bot collides with terrain. That makes the bot:

- run into walls for a few seconds;
- try to match the target's Y level instead of scaling hills;
- mine through hills instead of climbing them;
- break doors/trapdoors/gates instead of using them;
- mine as a first reaction when the target is behind terrain.

## What changed

### New navigation classes

Added a server-side terrain navigation stack in `legacyagent`:

- `NavigationController`
- `TerrainPathfinder`
- `TerrainReader`
- `NavigationConfig`
- `NavPath`
- `NavStep`
- `NavAction`
- `NavNode`
- `BlockKey`

### Movement integration

`LegacyMovementStrategy` now routes movement through the navigator:

- full-replacement NN remains unchanged;
- movement-controller NN gets first attempt;
- if movement-controller NN cannot move, the new navigator replaces the old direct-vector fallback;
- plain legacy mode uses the navigator first;
- old legacy movement remains as emergency fallback when navigation is disabled/configured to allow it.

### Config

Added `ai.navigation` options to `config.yml`:

- `enabled`
- `apply-to-movement-controller-fallback`
- `suppress-legacy-fallback`
- `allow-break-fallback`
- `open-doors`
- `open-trapdoors`
- `open-gates`
- `avoid-hazards`
- `max-nodes`
- `replan-interval-ticks`
- `target-predict-ticks`
- `max-drop-blocks`
- `max-search-distance`
- `goal-radius`
- `line-of-sight-goal-radius`

### Documentation

Added `docs/NAVIGATION_PATHFINDING.md` covering:

- the old failure mode;
- the two-pass route model;
- openable handling;
- planned mining semantics;
- expected behavior for walls, hills, doors, trapdoors, gates, sealed boxes, and hazards;
- follow-up work.

## Expected behavior

| Scenario | Expected behavior |
| --- | --- |
| 3x3 wall between bot and target | Route around the wall if reachable. |
| Target above a hill | Ascend terrain instead of mining through the hill. |
| Closed door | Open and continue. |
| Closed trapdoor/gate | Open when it blocks the planned clearance. |
| Target inside a sealed box | No-break search fails; break-enabled search selects the cheapest breach. |
| Lava/fire/magma/powder snow route | Avoid when hazard avoidance is enabled. |

## Notes / limitations

- Planned breach currently breaks the selected block immediately rather than reusing the old crack-progress mining animation. That keeps this PR focused on route selection; a follow-up can wire planned mining into the existing crack packet pipeline.
- Parkour is limited to terrain-safe primitives for now: one-block ascent, descent, bounded drops, diagonals, and route replanning. Gap-jump timing should be a follow-up once the baseline is stable.
- Goal satisfaction requires line of sight near the target so a boxed target should not be considered reachable just because the bot is standing outside the wall.

## Validation

I could not run a local Gradle build in this environment because the runtime cannot clone GitHub and does not have the GitHub CLI installed. I did a connector-backed diff inspection and a manual Java integration pass over the touched files. This is opened as a draft PR for in-repo CI/manual arena testing.