### PR TITLE
Retain verified combat work; defer navigation overhaul

### DIFF
--- a/CODEX.md
+++ b/CODEX.md
@@ -31,10 +31,10 @@ Update or flag the stale doc in a scoped docs task.
 
 ## Active branch target
 
-- Primary active target: `mc-26.2`.
-- Current 1v1 PvP strategy work starts from `mc-26.2`.
-- `mc-26.2` is the intended default branch.
-- `master` is legacy/display only, not the current development source of truth.
+- Primary active target: `master`.
+- Current 1v1 PvP strategy work starts from `master`.
+- `master` is the intended default branch and current development source of truth.
+- `mc-26.2` is a version-specific compatibility/reference branch unless a task explicitly scopes it.
 - `mc-26.1.2` is older compatibility/reference unless a task explicitly scopes
   that branch.
 - `mc-1.21.11` is older compatibility/reference unless a task explicitly scopes
@@ -89,8 +89,9 @@ explicitly asks.
 ## Branch rules
 
 - Work on the branch named by the task. For current 1v1 strategy, that branch is
-  `mc-26.2`.
-- Do not treat `master` as the development source of truth.
+  `master`.
+- Do not treat `mc-26.2` as the development source of truth unless the task
+  explicitly scopes that branch.
 - Do not treat `mc-1.21.11` as primary for current strategy work.
 - If compatibility work is explicitly scoped, verify the relevant branch before
   editing and keep the change narrow.
@@ -168,7 +169,7 @@ executor/adaptor boundaries.
 ## Current 1v1 PvP strategy
 
 TerminatorPlus is focused on one strong 1v1 PvP bot versus one skilled human
-PvPer on the `mc-26.2` target branch.
+PvPer on the `master` target branch.
 
 The current priority is duel quality:
 
@@ -245,7 +246,8 @@ A change is acceptable only when:
 
 ## Things not to do
 
-- Do not use `master` as current source of truth.
+- Do not use `mc-26.2` as current source of truth unless a task explicitly
+  scopes that branch.
 - Do not use `mc-26.1.2` as current source of truth unless a task explicitly
   scopes older compatibility work.
 - Do not treat `mc-1.21.11` as primary for current strategy work.

--- a/TerminatorPlus-Plugin/build.gradle.kts
+++ b/TerminatorPlus-Plugin/build.gradle.kts
@@ -14,6 +14,10 @@ dependencies {
     paperweight.paperDevBundle("26.2.build.+")
 
     implementation(project(":TerminatorPlus-API"))
+
+    // Reuse the repository's existing JUnit version for focused combat policy tests.
+    testImplementation("org.junit.jupiter:junit-jupiter:5.11.0")
+    testRuntimeOnly("org.junit.platform:junit-platform-launcher:1.11.0")
 }
 
 tasks {
@@ -23,6 +27,9 @@ tasks {
     }
     javadoc {
         options.encoding = Charsets.UTF_8.name()
+    }
+    test {
+        useJUnitPlatform()
     }
     processResources {
         filteringCharset = Charsets.UTF_8.name()

--- a/TerminatorPlus-Plugin/src/main/java/net/nuggetmc/tplus/bot/Bot.java
+++ b/TerminatorPlus-Plugin/src/main/java/net/nuggetmc/tplus/bot/Bot.java
@@ -978,6 +978,12 @@ public class Bot extends ServerPlayer implements Terminator {
                             + " left=" + actionController.remainingTicks());
             return;
         }
+        if (entity instanceof org.bukkit.entity.LivingEntity living
+                && !hasCombatLineOfSight(living)) {
+            CombatDebugger.log(this, "attack-skip",
+                    "reason=line-of-sight target=" + entity.getType().name());
+            return;
+        }
         actionController.recordPrimaryAction(this, BotActionState.MELEE_ATTACK, "bot-attack", botInventory.getSelectedHotbarSlot());
 
         // Neural-network training relies on the deterministic legacy damage table so fitness
@@ -1051,6 +1057,27 @@ public class Bot extends ServerPlayer implements Terminator {
                                 + " held=" + mainhandType());
             }
         }
+    }
+
+    /**
+     * Bukkit's direct Player.attack(Entity) call does not perform the client
+     * ray-trace first. Keep combat damage behind the same block visibility
+     * requirement a real player attack has.
+     */
+    public boolean hasCombatLineOfSight(org.bukkit.entity.LivingEntity target) {
+        if (target == null || !target.isValid()) return false;
+        Location eye = getBukkitEntity().getEyeLocation();
+        if (eye.getWorld() == null || target.getWorld() != eye.getWorld()) return false;
+        Location body = target.getLocation().clone().add(0.0, target.getHeight() * 0.5, 0.0);
+        return clearCombatRay(eye, body) || clearCombatRay(eye, target.getEyeLocation());
+    }
+
+    private static boolean clearCombatRay(Location from, Location to) {
+        Vector delta = to.toVector().subtract(from.toVector());
+        double distance = delta.length();
+        if (distance < 1.0e-6) return true;
+        return from.getWorld().rayTraceBlocks(from, delta.normalize(), distance,
+                FluidCollisionMode.NEVER, true) == null;
     }
 
     @Override

--- a/TerminatorPlus-Plugin/src/main/java/net/nuggetmc/tplus/bot/combat/CombatDirector.java
+++ b/TerminatorPlus-Plugin/src/main/java/net/nuggetmc/tplus/bot/combat/CombatDirector.java
@@ -51,6 +51,7 @@ public final class CombatDirector {
     }
 
     public boolean tick(Bot bot, LivingEntity target) {
+        combo.tick(bot, target);
         if (target == null || !target.isValid()) return false;
         plan(bot, target, bot.getCombatIntent());
         // NN bots route combat through executePlannedCombat() inside move(), which is
@@ -69,6 +70,7 @@ public final class CombatDirector {
      * than execute(): no scanner, consumables, idle melee, or utility branches.
      */
     public boolean tickCommitted(Bot bot, LivingEntity target) {
+        combo.tick(bot, target);
         if (target == null || !target.isValid()) return false;
         CombatState.Phase phase = bot.getCombatState().getPhase();
         if (!isCommittedPhase(phase)) {
@@ -97,6 +99,7 @@ public final class CombatDirector {
      * attacks, mutate loadouts, or bypass CombatDirector execution gates.
      */
     public CombatIntent plan(Bot bot, LivingEntity target, CombatIntent previousIntent) {
+        combo.tick(bot, target);
         if (target == null || !target.isValid()) {
             bot.setCombatIntent(CombatIntent.DEFAULT);
             return bot.getCombatIntent();

--- a/TerminatorPlus-Plugin/src/main/java/net/nuggetmc/tplus/bot/combat/ComboBehavior.java
+++ b/TerminatorPlus-Plugin/src/main/java/net/nuggetmc/tplus/bot/combat/ComboBehavior.java
@@ -1,6 +1,7 @@
 package net.nuggetmc.tplus.bot.combat;
 
 import net.nuggetmc.tplus.TerminatorPlus;
+import net.nuggetmc.tplus.api.agent.legacyagent.LegacyUtils;
 import net.nuggetmc.tplus.bot.Bot;
 import org.bukkit.Location;
 import org.bukkit.Material;
@@ -9,6 +10,7 @@ import org.bukkit.entity.EnderPearl;
 import org.bukkit.entity.LivingEntity;
 import org.bukkit.entity.WindCharge;
 import org.bukkit.plugin.Plugin;
+import org.bukkit.scheduler.BukkitTask;
 import org.bukkit.util.Vector;
 
 import java.util.HashMap;
@@ -16,152 +18,464 @@ import java.util.Map;
 import java.util.UUID;
 
 /**
- * Two-step wind-charge + ender-pearl engage combo. The wind charge
- * detonation stacks its velocity onto the pearl thrown immediately after,
- * halving travel time and closing a 20+ block gap in one launch.
+ * Owns the wind-charge/ender-pearl finisher as one bounded combat action.
  *
- * <p>Bots don't disengage. A previous version had a mirror "escape"
- * combo; it was removed because bots were running from fights and
- * never re-engaging. Only the gap-closer remains.
- *
- * <p>A single instance is shared across all bots. Per-bot state lives
- * in the {@link #active} map and is cleaned up after the scheduled
- * pearl fires.
+ * <p>The old PR implementation used delayed direct spawns and then forced a
+ * pearl/charge collision with API calls that are not a reliable substitute for
+ * vanilla projectile physics. This implementation keeps the useful intercept
+ * calculation, but lets the server resolve the projectiles normally and only
+ * observes their proximity for debug telemetry.</p>
  */
 public final class ComboBehavior {
 
     public static final String COOLDOWN_KEY = "combo";
-    private static final int COOLDOWN_TICKS = 100;
-    /** Delay between wind charge spawn and pearl throw. Short enough that the pearl rides the blast wave. */
+    /** High-impact movement finisher: at most once per ten seconds per bot. */
+    public static final int COOLDOWN_TICKS = 200;
     private static final int PEARL_DELAY_TICKS = 2;
 
+    private static final int MIN_RELEASE_TICKS = 4;
+    private static final int MAX_RELEASE_TICKS = 28;
+    private static final int MONITOR_GRACE_TICKS = 8;
+    private static final int MAX_MONITOR_TICKS = 36;
+    private static final double INTERCEPT_MIN_DISTANCE = 30.0;
+    private static final double INTERCEPT_MAX_DISTANCE = 42.0;
+    private static final double WIND_SPEED = 1.20;
+    private static final double PEARL_SPEED = 1.95;
+    private static final double TARGET_LEAD_FACTOR = 0.35;
+    private static final double TARGET_LEAD_MAX_TICKS = 10.0;
+    private static final double INTERCEPT_MIN_TICKS = 1.0;
+    private static final double INTERCEPT_MAX_TICKS = 32.0;
+    private static final double PEARL_GRAVITY_COMPENSATION = 0.03;
+    private static final double CONTACT_RADIUS_SQ = 1.25 * 1.25;
+
     public enum ComboType {
-        WIND_PEARL_ENGAGE
+        WIND_PEARL_ENGAGE,
+        WIND_PEARL_INTERCEPT
     }
 
-    private final Plugin plugin;
-    private final Map<UUID, Integer> active = new HashMap<>();
+    private final Map<UUID, ActiveCombo> active = new HashMap<>();
 
     public ComboBehavior(Plugin plugin) {
         if (plugin == null) {
             throw new IllegalArgumentException(
-                "ComboBehavior requires a non-null Plugin — runTaskLater on a null plugin NPEs.");
+                    "ComboBehavior requires a non-null Plugin — runTaskLater on a null plugin NPEs.");
         }
-        this.plugin = plugin;
     }
 
-    /**
-     * Convenience constructor that grabs the TerminatorPlus singleton directly
-     * rather than going through {@code Bukkit.getPluginManager().getPlugin("TerminatorPlus")}.
-     * The previous by-name lookup returned {@code null} if the plugin was renamed /
-     * shaded under a different key, which later NPE'd inside {@code runTaskLater};
-     * {@link TerminatorPlus#getInstance()} is always correct once {@code onEnable}
-     * has run (which is well before any bot exists to combo).
-     */
     public ComboBehavior() {
         this(TerminatorPlus.getInstance());
     }
 
+    /** PR #11's intended wind-pearl window. Ordinary pearls handle other ranges. */
+    public static boolean isInterceptRange(double distance) {
+        return distance >= INTERCEPT_MIN_DISTANCE && distance <= INTERCEPT_MAX_DISTANCE;
+    }
+
+    public static ComboType typeForDistance(double distance) {
+        return isInterceptRange(distance)
+                ? ComboType.WIND_PEARL_INTERCEPT
+                : ComboType.WIND_PEARL_ENGAGE;
+    }
+
     public boolean inProgress(Bot bot) {
-        Integer endTick = active.get(bot.getUUID());
-        if (endTick == null) return false;
-        if (bot.getAliveTicks() > endTick) {
-            active.remove(bot.getUUID());
+        if (bot == null) return false;
+        ActiveCombo run = active.get(bot.getUUID());
+        if (run == null) return false;
+        if (!bot.isBotAlive() || bot.getAliveTicks() > run.expiresAtTick) {
+            cancel(run, "expired", true);
             return false;
         }
         return true;
     }
 
+    /** Cancel a combo during bot removal or director cleanup. */
     public void clear(UUID botId) {
-        if (botId != null) {
-            active.remove(botId);
+        if (botId == null) return;
+        ActiveCombo run = active.get(botId);
+        if (run != null) cancel(run, "cleanup", true);
+    }
+
+    /** Cancel when the director sees a changed target or world before movement runs. */
+    public void tick(Bot bot, LivingEntity target) {
+        if (bot == null) return;
+        ActiveCombo run = active.get(bot.getUUID());
+        if (run == null) return;
+        if (!bot.isBotAlive() || target == null || !target.isValid()
+                || !run.targetId.equals(target.getUniqueId())
+                || target.getWorld() != bot.getLocation().getWorld()) {
+            cancel(run, "target-invalid-or-changed", true);
         }
     }
 
     public boolean canCombo(Bot bot) {
-        if (inProgress(bot)) return false;
-        return bot.getBotCooldowns().ready(COOLDOWN_KEY, bot.getAliveTicks());
+        if (bot == null || inProgress(bot)) return false;
+        int alive = bot.getAliveTicks();
+        return bot.getBotCooldowns().ready(COOLDOWN_KEY, alive)
+                && bot.getBotCooldowns().ready(WindChargeBehavior.COOLDOWN_KEY, alive)
+                && bot.getBotCooldowns().ready(EnderPearlBehavior.COOLDOWN_KEY, alive)
+                && !bot.getActionController().active();
     }
 
     public boolean start(Bot bot, LivingEntity target, ComboType type) {
-        if (!canCombo(bot)) return false;
-        if (!bot.getBotInventory().hasWindCharge()) return false;
-        if (!bot.getBotInventory().hasEnderPearl()) return false;
-
-        int alive = bot.getAliveTicks();
-        active.put(bot.getUUID(), alive + PEARL_DELAY_TICKS + 10);
-
-        bot.getBotCooldowns().set(COOLDOWN_KEY, COOLDOWN_TICKS, alive);
-        bot.getBotCooldowns().set(WindChargeBehavior.COOLDOWN_KEY, 55, alive);
-
-        boolean launched = switch (type) {
-            case WIND_PEARL_ENGAGE -> launchEngage(bot, target);
-        };
-        if (!launched) {
-            active.remove(bot.getUUID());
+        if (bot == null || target == null || type == null || !canCombo(bot)) return false;
+        if (!bot.isBotAlive() || !target.isValid() || target.getWorld() != bot.getLocation().getWorld()) {
+            CombatDebugger.log(bot, "wind-pearl-skip", "reason=target-invalid-or-world");
+            return false;
         }
-        return launched;
-    }
+        if (!bot.isBotOnGround() || bot.getCombatState().getPhase() != CombatState.Phase.IDLE) {
+            CombatDebugger.log(bot, "wind-pearl-skip", "reason=bot-not-grounded-or-idle");
+            return false;
+        }
+        if (!bot.getBotInventory().hasWindCharge() || !bot.getBotInventory().hasEnderPearl()) {
+            CombatDebugger.log(bot, "wind-pearl-skip", "reason=missing-combo-items");
+            return false;
+        }
+        if (!hasTargetLineOfSight(bot, target)) {
+            CombatDebugger.log(bot, "wind-pearl-skip", "reason=no-line-of-sight");
+            return false;
+        }
 
-    private boolean launchEngage(Bot bot, LivingEntity target) {
-        Location botLoc = bot.getLocation();
-        Vector forward = horizontalTo(botLoc, target.getLocation());
-        if (forward == null) return false;
+        Location windSpawn = bot.getLocation().clone()
+                .add(0, bot.getBukkitEntity().getEyeHeight() - 0.1, 0);
+        ComboPlan plan = type == ComboType.WIND_PEARL_INTERCEPT
+                ? buildInterceptPlan(bot, target, windSpawn)
+                : buildEngagePlan(bot, target, windSpawn);
+        if (plan == null) return false;
 
-        // Step 1: wind charge behind the bot. Explosion pushes the bot forward.
-        Location behind = botLoc.clone().add(forward.clone().multiply(-0.8)).add(0, 0.4, 0);
-        spawnWindCharge(bot, behind, forward.clone().multiply(-0.4).setY(-0.2));
+        int previousSlot = bot.getBotInventory().getSelectedHotbarSlot();
+        int windSlot = bot.getBotInventory().findMainInventory(Material.WIND_CHARGE);
+        int selectedWindSlot = windSlot >= 0
+                ? bot.getBotInventory().selectMainInventorySlot(windSlot)
+                : previousSlot;
+        if (windSlot >= 0 && selectedWindSlot < 0) {
+            CombatDebugger.log(bot, "wind-pearl-skip", "reason=no-selectable-wind-charge");
+            return false;
+        }
 
-        // Step 2 (2 ticks later): throw pearl forward along the same line.
-        bot.scheduleBotTask(() -> {
-            try {
-                if (!bot.isBotAlive()) return;
-                int slot = bot.getBotInventory().findHotbar(Material.ENDER_PEARL);
-                if (slot >= 0) {
-                    slot = bot.getBotInventory().selectMainInventorySlot(slot);
-                }
-                if (slot < 0) {
-                    return;
-                }
-                Location spawn = bot.getLocation().add(0, bot.getBukkitEntity().getEyeHeight() - 0.1, 0);
-                Vector aim = target.getEyeLocation().toVector().subtract(spawn.toVector()).normalize();
-                aim.setY(aim.getY() + 0.08).normalize();
-                bot.faceLocation(target.getLocation());
-                bot.punch();
-                spawn.getWorld().spawn(spawn, EnderPearl.class, p -> {
-                    p.setShooter(bot.getBukkitEntity());
-                    p.setVelocity(aim.multiply(2.2));
-                });
-                spawn.getWorld().playSound(spawn, Sound.ENTITY_ENDER_PEARL_THROW, 1f, 1f);
-                bot.getBotInventory().decrementMainInventorySlot(slot, 1);
-            } finally {
-                active.remove(bot.getUUID());
+        ActiveCombo run = new ActiveCombo(bot, target, type, previousSlot,
+                bot.getAliveTicks() + plan.releaseTicks + plan.monitorTicks + 4, plan);
+        active.put(bot.getUUID(), run);
+
+        boolean started = bot.getActionController().start(bot, BotActionState.USING_WIND_CHARGE,
+                plan.releaseTicks, selectedWindSlot, "wind-pearl-combo",
+                () -> releasePearl(run));
+        if (!started) {
+            cancel(run, "action-busy", false);
+            return false;
+        }
+
+        if (!bot.getBotInventory().decrementMaterialOrOffhand(Material.WIND_CHARGE)) {
+            cancel(run, "no-wind-stack", true);
+            return false;
+        }
+
+        try {
+            bot.faceLocation(target.getLocation());
+            bot.punch();
+            run.charge = spawnCharge(bot, plan.windSpawn, plan.windAim);
+            if (run.charge == null) {
+                cancel(run, "wind-spawn-failed", true);
+                return false;
             }
-        }, PEARL_DELAY_TICKS);
+            plan.windSpawn.getWorld().playSound(plan.windSpawn,
+                    Sound.ENTITY_WIND_CHARGE_THROW, 1f, 1.05f);
+        } catch (RuntimeException ex) {
+            CombatDebugger.log(bot, "wind-pearl-cancel", "reason=wind-spawn-exception type="
+                    + ex.getClass().getSimpleName());
+            cancel(run, "wind-spawn-exception", true);
+            return false;
+        }
+
+        bot.getActionController().recordDirectShortcut(bot, BotActionState.USING_WIND_CHARGE,
+                "wind-pearl-wind-spawn", selectedWindSlot);
+        int alive = bot.getAliveTicks();
+        bot.getBotCooldowns().set(COOLDOWN_KEY, COOLDOWN_TICKS, alive);
+        bot.getBotCooldowns().set(WindChargeBehavior.COOLDOWN_KEY,
+                WindChargeBehavior.COOLDOWN_TICKS, alive);
+        // Keep the ordinary-pearl fallback from bypassing the combo throttle.
+        bot.getBotCooldowns().set(EnderPearlBehavior.COOLDOWN_KEY, COOLDOWN_TICKS, alive);
+        bot.getCombatState().markExecuted(alive);
+        CombatDebugger.log(bot, "wind-pearl-start",
+                "type=" + type.name()
+                        + " dist=" + String.format("%.2f", bot.getLocation().distance(target.getLocation()))
+                        + " release=" + plan.releaseTicks
+                        + " monitor=" + plan.monitorTicks);
         return true;
     }
 
-    private static void spawnWindCharge(Bot bot, Location at, Vector velocity) {
-        int slot = bot.getBotInventory().findHotbar(Material.WIND_CHARGE);
-        if (slot >= 0) {
-            slot = bot.getBotInventory().selectMainInventorySlot(slot);
+    private void releasePearl(ActiveCombo run) {
+        Bot bot = run.bot;
+        LivingEntity target = run.target;
+        if (!isValid(run) || !target.isValid() || target.getWorld() != bot.getLocation().getWorld()) {
+            cancel(run, "target-or-charge-invalid", false);
+            return;
         }
-        bot.punch();
-        at.getWorld().spawn(at, WindCharge.class, w -> {
+
+        int pearlSlot = bot.getBotInventory().selectMaterial(Material.ENDER_PEARL);
+        if (pearlSlot < 0) {
+            cancel(run, "no-selectable-pearl", false);
+            return;
+        }
+
+        Location spawn = bot.getLocation().clone()
+                .add(0, bot.getBukkitEntity().getEyeHeight() - 0.1, 0);
+        Vector velocity = run.type == ComboType.WIND_PEARL_INTERCEPT
+                ? solvePearlInterceptVelocity(spawn, run.charge)
+                : engageVelocity(spawn, target);
+        if (velocity == null) {
+            cancel(run, "no-pearl-trajectory", false);
+            return;
+        }
+
+        EnderPearl pearl;
+        try {
+            bot.faceLocation(run.charge == null ? target.getLocation() : run.charge.getLocation());
+            bot.punch();
+            bot.getActionController().recordDirectShortcut(bot, BotActionState.USING_PEARL,
+                    "wind-pearl-release", pearlSlot);
+            pearl = spawn.getWorld().spawn(spawn, EnderPearl.class, p -> {
+                p.setShooter(bot.getBukkitEntity());
+                p.setVelocity(velocity);
+            });
+        } catch (RuntimeException ex) {
+            CombatDebugger.log(bot, "wind-pearl-cancel", "reason=pearl-spawn-exception type="
+                    + ex.getClass().getSimpleName());
+            cancel(run, "pearl-spawn-exception", false);
+            return;
+        }
+
+        if (!bot.getBotInventory().decrementMainInventorySlot(pearlSlot, 1)) {
+            pearl.remove();
+            cancel(run, "pearl-consume-failed", false);
+            return;
+        }
+
+        spawn.getWorld().playSound(spawn, Sound.ENTITY_ENDER_PEARL_THROW, 1f, 1f);
+        bot.getBotInventory().restoreSelectedSlotOrBestWeapon(run.previousSlot);
+        bot.getBotCooldowns().set(EnderPearlBehavior.COOLDOWN_KEY,
+                COOLDOWN_TICKS, bot.getAliveTicks());
+        run.pearl = pearl;
+        run.released = true;
+        CombatDebugger.log(bot, "wind-pearl-throw",
+                "type=" + run.type.name()
+                        + " slot=" + pearlSlot
+                        + " speed=" + String.format("%.2f", velocity.length()));
+        monitor(run, run.plan.monitorTicks);
+    }
+
+    private void monitor(ActiveCombo run, int ticksLeft) {
+        if (!active.containsKey(run.bot.getUUID())) return;
+        if (run.pearl == null || !run.pearl.isValid() || run.charge == null || !run.charge.isValid()
+                || run.pearl.getWorld() != run.charge.getWorld()) {
+            finish(run, "projectile-ended");
+            return;
+        }
+
+        double distanceSq = run.pearl.getLocation().distanceSquared(run.charge.getLocation());
+        if (distanceSq <= CONTACT_RADIUS_SQ) {
+            CombatDebugger.log(run.bot, "wind-pearl-contact-observed",
+                    "dist=" + String.format("%.2f", Math.sqrt(distanceSq))
+                            + " nativePhysics=true");
+            finish(run, "contact-observed");
+            return;
+        }
+        if (ticksLeft <= 0) {
+            CombatDebugger.log(run.bot, "wind-pearl-miss",
+                    "dist=" + String.format("%.2f", Math.sqrt(distanceSq)));
+            finish(run, "monitor-expired");
+            return;
+        }
+
+        run.monitorTask = run.bot.scheduleBotTask(() -> {
+            run.monitorTask = null;
+            monitor(run, ticksLeft - 1);
+        }, 1L);
+        if (run.monitorTask == null) finish(run, "bot-removed");
+    }
+
+    private boolean isValid(ActiveCombo run) {
+        return active.get(run.bot.getUUID()) == run
+                && run.bot.isBotAlive()
+                && run.charge != null
+                && run.charge.isValid();
+    }
+
+    private void finish(ActiveCombo run, String reason) {
+        if (active.get(run.bot.getUUID()) != run) return;
+        active.remove(run.bot.getUUID());
+        cancelMonitor(run);
+        run.bot.getBotInventory().restoreSelectedSlotOrBestWeapon(run.previousSlot);
+        CombatDebugger.log(run.bot, "wind-pearl-end", "reason=" + reason + " released=" + run.released);
+    }
+
+    private void cancel(ActiveCombo run, String reason, boolean interruptAction) {
+        if (active.get(run.bot.getUUID()) != run) return;
+        active.remove(run.bot.getUUID());
+        cancelMonitor(run);
+        if (interruptAction) {
+            run.bot.getActionController().interrupt(run.bot, "wind-pearl-" + reason);
+        }
+        run.bot.getBotInventory().restoreSelectedSlotOrBestWeapon(run.previousSlot);
+        CombatDebugger.log(run.bot, "wind-pearl-cancel", "reason=" + reason);
+    }
+
+    private static void cancelMonitor(ActiveCombo run) {
+        if (run.monitorTask != null && !run.monitorTask.isCancelled()) {
+            run.monitorTask.cancel();
+        }
+        run.monitorTask = null;
+    }
+
+    private static ComboPlan buildEngagePlan(Bot bot, LivingEntity target, Location spawn) {
+        Vector forward = horizontalTo(bot.getLocation(), target.getLocation());
+        if (forward == null) return null;
+        Location windSpawn = bot.getLocation().clone()
+                .add(forward.clone().multiply(-0.8)).add(0, 0.4, 0);
+        return new ComboPlan(windSpawn, forward.clone().multiply(-0.4).setY(-0.2),
+                PEARL_DELAY_TICKS, 20);
+    }
+
+    private static ComboPlan buildInterceptPlan(Bot bot, LivingEntity target, Location windSpawn) {
+        Vector roughContact = comboPoint(bot, target, 0.0);
+        double roughWindTicks = roughContact.distance(windSpawn.toVector()) / WIND_SPEED;
+        double targetLeadTicks = Math.min(TARGET_LEAD_MAX_TICKS,
+                Math.max(0.0, roughWindTicks * TARGET_LEAD_FACTOR));
+        Vector contactPoint = comboPoint(bot, target, targetLeadTicks);
+        Vector windToContact = contactPoint.clone().subtract(windSpawn.toVector());
+        double distance = windToContact.length();
+        if (distance < 1.0e-6) return null;
+
+        double windTravelTicks = distance / WIND_SPEED;
+        double pearlTravelTicks = distance / PEARL_SPEED;
+        int releaseTicks = clamp((int) Math.round(windTravelTicks - pearlTravelTicks),
+                MIN_RELEASE_TICKS, MAX_RELEASE_TICKS);
+        int monitorTicks = clamp((int) Math.ceil(pearlTravelTicks + MONITOR_GRACE_TICKS),
+                8, MAX_MONITOR_TICKS);
+        return new ComboPlan(windSpawn, windToContact.normalize().multiply(WIND_SPEED),
+                releaseTicks, monitorTicks);
+    }
+
+    private static Vector engageVelocity(Location spawn, LivingEntity target) {
+        Vector aimPoint = target.getEyeLocation().toVector()
+                .add(target.getVelocity().clone().multiply(0.75));
+        Vector velocity = aimPoint.subtract(spawn.toVector());
+        if (velocity.lengthSquared() < 1.0e-6) return null;
+        velocity.normalize().setY(velocity.getY() + 0.08).normalize();
+        return velocity.multiply(2.2);
+    }
+
+    private static Vector solvePearlInterceptVelocity(Location spawn, WindCharge charge) {
+        if (charge == null || !charge.isValid() || charge.getWorld() != spawn.getWorld()) return null;
+        Vector origin = spawn.toVector();
+        Vector chargePosition = charge.getLocation().toVector();
+        Vector chargeVelocity = charge.getVelocity();
+        double ticks = solveLinearInterceptTicks(origin, chargePosition, chargeVelocity, PEARL_SPEED);
+        ticks = clamp(ticks, INTERCEPT_MIN_TICKS, INTERCEPT_MAX_TICKS);
+
+        for (int i = 0; i < 3; i++) {
+            Vector aimPoint = chargePosition.clone().add(chargeVelocity.clone().multiply(ticks));
+            aimPoint.setY(aimPoint.getY() + gravityCompensation(ticks));
+            ticks = clamp(aimPoint.distance(origin) / PEARL_SPEED,
+                    INTERCEPT_MIN_TICKS, INTERCEPT_MAX_TICKS);
+        }
+
+        Vector aimPoint = chargePosition.clone().add(chargeVelocity.clone().multiply(ticks));
+        aimPoint.setY(aimPoint.getY() + gravityCompensation(ticks));
+        Vector velocity = aimPoint.subtract(origin);
+        if (velocity.lengthSquared() < 1.0e-6) return null;
+        return velocity.normalize().multiply(PEARL_SPEED);
+    }
+
+    static double solveLinearInterceptTicks(Vector origin, Vector targetPosition,
+                                            Vector targetVelocity, double speed) {
+        Vector delta = targetPosition.clone().subtract(origin);
+        double a = targetVelocity.lengthSquared() - speed * speed;
+        double b = 2.0 * delta.dot(targetVelocity);
+        double c = delta.lengthSquared();
+        if (c < 1.0e-6) return 0.0;
+        if (Math.abs(a) < 1.0e-6) {
+            if (Math.abs(b) < 1.0e-6) return Math.sqrt(c) / speed;
+            double linear = -c / b;
+            return linear > 0.0 && Double.isFinite(linear) ? linear : Math.sqrt(c) / speed;
+        }
+
+        double discriminant = b * b - 4.0 * a * c;
+        if (discriminant < 0.0) return Math.sqrt(c) / speed;
+        double root = Math.sqrt(discriminant);
+        double t1 = (-b - root) / (2.0 * a);
+        double t2 = (-b + root) / (2.0 * a);
+        double best = Double.POSITIVE_INFINITY;
+        if (t1 > 0.0 && Double.isFinite(t1)) best = t1;
+        if (t2 > 0.0 && Double.isFinite(t2)) best = Math.min(best, t2);
+        return Double.isFinite(best) ? best : Math.sqrt(c) / speed;
+    }
+
+    private static Vector comboPoint(Bot bot, LivingEntity target, double leadTicks) {
+        Vector predictedEye = target.getEyeLocation().toVector()
+                .add(target.getVelocity().clone().multiply(Math.max(0.0, leadTicks)));
+        Vector fromTargetToBot = bot.getLocation().toVector().subtract(predictedEye).setY(0);
+        if (fromTargetToBot.lengthSquared() > 1.0e-6) {
+            fromTargetToBot.normalize().multiply(1.25);
+        }
+        return predictedEye.add(fromTargetToBot).add(new Vector(0, -0.25, 0));
+    }
+
+    private static WindCharge spawnCharge(Bot bot, Location spawn, Vector velocity) {
+        return spawn.getWorld().spawn(spawn, WindCharge.class, w -> {
             w.setShooter(bot.getBukkitEntity());
-            w.setVelocity(velocity);
+            w.setVelocity(velocity.clone());
         });
-        at.getWorld().playSound(at, Sound.ENTITY_WIND_CHARGE_THROW, 1f, 1.0f);
-        if (slot >= 0) {
-            bot.getBotInventory().decrementMainInventorySlot(slot, 1);
-        } else {
-            bot.getBotInventory().decrementMaterialOrOffhand(Material.WIND_CHARGE);
-        }
+    }
+
+    private static boolean hasTargetLineOfSight(Bot bot, LivingEntity target) {
+        Location eye = bot.getBukkitEntity().getEyeLocation();
+        return LegacyUtils.checkFreeSpace(eye, target.getEyeLocation())
+                || LegacyUtils.checkFreeSpace(eye, target.getLocation());
     }
 
     private static Vector horizontalTo(Location from, Location to) {
-        Vector v = to.toVector().subtract(from.toVector()).setY(0);
-        if (v.lengthSquared() < 1.0e-6) return null;
-        return v.normalize();
+        Vector vector = to.toVector().subtract(from.toVector()).setY(0);
+        if (vector.lengthSquared() < 1.0e-6) return null;
+        return vector.normalize();
+    }
+
+    private static double gravityCompensation(double ticks) {
+        return 0.5 * PEARL_GRAVITY_COMPENSATION * ticks * ticks;
+    }
+
+    private static int clamp(int value, int min, int max) {
+        return Math.max(min, Math.min(max, value));
+    }
+
+    private static double clamp(double value, double min, double max) {
+        if (!Double.isFinite(value)) return min;
+        return Math.max(min, Math.min(max, value));
+    }
+
+    private record ComboPlan(Location windSpawn, Vector windAim, int releaseTicks, int monitorTicks) {}
+
+    private static final class ActiveCombo {
+        private final Bot bot;
+        private final LivingEntity target;
+        private final UUID targetId;
+        private final ComboType type;
+        private final int previousSlot;
+        private final int expiresAtTick;
+        private final ComboPlan plan;
+        private WindCharge charge;
+        private EnderPearl pearl;
+        private BukkitTask monitorTask;
+        private boolean released;
+
+        private ActiveCombo(Bot bot, LivingEntity target, ComboType type, int previousSlot,
+                            int expiresAtTick, ComboPlan plan) {
+            this.bot = bot;
+            this.target = target;
+            this.targetId = target.getUniqueId();
+            this.type = type;
+            this.previousSlot = previousSlot;
+            this.expiresAtTick = expiresAtTick;
+            this.plan = plan;
+        }
     }
 }

--- a/TerminatorPlus-Plugin/src/main/java/net/nuggetmc/tplus/bot/combat/EnderPearlBehavior.java
+++ b/TerminatorPlus-Plugin/src/main/java/net/nuggetmc/tplus/bot/combat/EnderPearlBehavior.java
@@ -18,7 +18,7 @@ import org.bukkit.util.Vector;
 public final class EnderPearlBehavior {
 
     public static final String COOLDOWN_KEY = "pearl";
-    private static final int COOLDOWN = 60;
+    public static final int COOLDOWN_TICKS = 60;
     /** Match the user-facing "use pearls beyond 28 blocks" rule. Inside this radius, walk/trident. */
     private static final double MIN_DISTANCE = 28.0;
     /** Vanilla pearls have ~30-block reach before falling out of the air; cap so we don't waste throws. */
@@ -85,7 +85,7 @@ public final class EnderPearlBehavior {
             bot.getBotInventory().restoreSelectedSlotOrBestWeapon(previousSlot);
             return 0;
         }
-        bot.getBotCooldowns().set(COOLDOWN_KEY, COOLDOWN, alive);
-        return COOLDOWN;
+        bot.getBotCooldowns().set(COOLDOWN_KEY, COOLDOWN_TICKS, alive);
+        return COOLDOWN_TICKS;
     }
 }

--- a/TerminatorPlus-Plugin/src/main/java/net/nuggetmc/tplus/bot/combat/MaceBehavior.java
+++ b/TerminatorPlus-Plugin/src/main/java/net/nuggetmc/tplus/bot/combat/MaceBehavior.java
@@ -263,7 +263,8 @@ public final class MaceBehavior {
                         + " charge=" + fmt(bot.getAttackStrengthScale(0.0f))
                         + " held=" + heldType(bot));
         bot.getBotCooldowns().set(COOLDOWN_KEY, JUMP_COOLDOWN, bot.getAliveTicks());
-        bot.getBotCooldowns().set(WindChargeBehavior.COOLDOWN_KEY, 55, bot.getAliveTicks());
+        bot.getBotCooldowns().set(WindChargeBehavior.COOLDOWN_KEY,
+                WindChargeBehavior.COOLDOWN_TICKS, bot.getAliveTicks());
         CombatDebugger.macePhase(bot, state.getPhase(), CombatState.Phase.AIRBORNE);
         state.setPhase(CombatState.Phase.AIRBORNE);
         state.setPhaseStartY(startY);
@@ -398,6 +399,10 @@ public final class MaceBehavior {
                             + " held=" + heldType(bot));
         }
 
+        if (!bot.hasCombatLineOfSight(target)) {
+            CombatDebugger.log(bot, "mace-attack-skip", "reason=line-of-sight");
+            return;
+        }
         bot.punch();
         if (bot.getBukkitEntity() instanceof Player attacker) {
             attacker.attack(target);

--- a/TerminatorPlus-Plugin/src/main/java/net/nuggetmc/tplus/bot/combat/MeleeBehavior.java
+++ b/TerminatorPlus-Plugin/src/main/java/net/nuggetmc/tplus/bot/combat/MeleeBehavior.java
@@ -22,7 +22,8 @@ import org.bukkit.inventory.ItemStack;
  */
 public final class MeleeBehavior {
 
-    public static final double ATTACK_RANGE = 5.0;
+    /** Keep melee inside the same 3.5-block contract used by the scanner and wiki. */
+    public static final double ATTACK_RANGE = 3.5;
 
     public int ticksFor(Bot bot, LivingEntity target, double distance) {
         if (distance > ATTACK_RANGE) {

--- a/TerminatorPlus-Plugin/src/main/java/net/nuggetmc/tplus/bot/combat/OpportunityScanner.java
+++ b/TerminatorPlus-Plugin/src/main/java/net/nuggetmc/tplus/bot/combat/OpportunityScanner.java
@@ -541,7 +541,8 @@ public final class OpportunityScanner {
         }
 
         if (snap.targetHpFraction < FINISHER_HP_FRAC && snap.distance >= 5.0) {
-            if (snap.distance >= 18.0 && inv.hasWindCharge() && inv.hasEnderPearl()
+            if (ComboBehavior.isInterceptRange(snap.distance)
+                    && inv.hasWindCharge() && inv.hasEnderPearl()
                     && combo.canCombo(bot)
                     && bot.getBotCooldowns().ready(EnderPearlBehavior.COOLDOWN_KEY, alive)) {
                 return ScannerPlan.of(ScannerPlay.FINISHER_COMBO);
@@ -589,7 +590,7 @@ public final class OpportunityScanner {
             case KNOCKUP_CRYSTAL -> {
                 if (executeKnockupCrystal(bot, target)) {
                     bot.getBotCooldowns().set(KNOCKUP_CD, 60, alive);
-                    bot.getBotCooldowns().set(WindChargeBehavior.COOLDOWN_KEY, 55, alive);
+                    bot.getBotCooldowns().set(WindChargeBehavior.COOLDOWN_KEY, WindChargeBehavior.COOLDOWN_TICKS, alive);
                     return true;
                 }
             }
@@ -766,7 +767,7 @@ public final class OpportunityScanner {
             }
             case FINISHER_COMBO -> {
                 if (combo.canCombo(bot)) {
-                    return combo.start(bot, target, ComboBehavior.ComboType.WIND_PEARL_ENGAGE);
+                    return combo.start(bot, target, ComboBehavior.ComboType.WIND_PEARL_INTERCEPT);
                 }
             }
             case FINISHER_TRIDENT -> {
@@ -855,7 +856,7 @@ public final class OpportunityScanner {
                 && bot.getBotCooldowns().ready(WindChargeBehavior.COOLDOWN_KEY, alive)) {
             if (executeKnockupCrystal(bot, target)) {
                 bot.getBotCooldowns().set(KNOCKUP_CD, 60, alive);
-                bot.getBotCooldowns().set(WindChargeBehavior.COOLDOWN_KEY, 55, alive);
+                bot.getBotCooldowns().set(WindChargeBehavior.COOLDOWN_KEY, WindChargeBehavior.COOLDOWN_TICKS, alive);
                 return true;
             }
         }
@@ -1394,8 +1395,9 @@ public final class OpportunityScanner {
         spawnLoc.getWorld().playSound(feet, Sound.ENTITY_WIND_CHARGE_THROW, 1f, 1.2f);
         consumeOne(bot, Material.WIND_CHARGE);
 
-        bot.getBotCooldowns().set(WindChargeBehavior.COOLDOWN_KEY, 55, bot.getAliveTicks());
-        bot.getBotCooldowns().set(ComboBehavior.COOLDOWN_KEY, 100, bot.getAliveTicks());
+        bot.getBotCooldowns().set(WindChargeBehavior.COOLDOWN_KEY, WindChargeBehavior.COOLDOWN_TICKS, bot.getAliveTicks());
+        bot.getBotCooldowns().set(ComboBehavior.COOLDOWN_KEY,
+                ComboBehavior.COOLDOWN_TICKS, bot.getAliveTicks());
         return true;
     }
 
@@ -1625,7 +1627,7 @@ public final class OpportunityScanner {
             if (executeKnockupCrystal(bot, target)) {
                 CombatDebugger.log(bot, "opp-fire", "name=INTERRUPT via=wind-charge");
                 bot.getBotCooldowns().set(cdKey, cdTicks, alive);
-                bot.getBotCooldowns().set(WindChargeBehavior.COOLDOWN_KEY, 55, alive);
+                bot.getBotCooldowns().set(WindChargeBehavior.COOLDOWN_KEY, WindChargeBehavior.COOLDOWN_TICKS, alive);
                 return true;
             }
         }
@@ -1893,10 +1895,11 @@ public final class OpportunityScanner {
         BotInventory inv = bot.getBotInventory();
         int alive = bot.getAliveTicks();
 
-        if (snap.distance >= 18.0 && inv.hasWindCharge() && inv.hasEnderPearl()
+        if (ComboBehavior.isInterceptRange(snap.distance)
+                && inv.hasWindCharge() && inv.hasEnderPearl()
                 && combo.canCombo(bot)
                 && bot.getBotCooldowns().ready(EnderPearlBehavior.COOLDOWN_KEY, alive)) {
-            return combo.start(bot, target, ComboBehavior.ComboType.WIND_PEARL_ENGAGE);
+            return combo.start(bot, target, ComboBehavior.ComboType.WIND_PEARL_INTERCEPT);
         }
 
         if (snap.distance >= 8.0 && snap.distance <= 28.0 && inv.hasTrident()
@@ -1942,7 +1945,11 @@ public final class OpportunityScanner {
         });
         spawn.getWorld().playSound(spawn, Sound.ENTITY_ENDER_PEARL_THROW, 1f, 1f);
         bot.getBotInventory().decrementMainInventorySlot(slot, 1);
-        bot.getBotCooldowns().set(EnderPearlBehavior.COOLDOWN_KEY, 60, bot.getAliveTicks());
+        CombatDebugger.log(bot, "pearl-throw",
+                "source=finisher dist=" + String.format("%.2f", bot.getLocation().distance(target.getLocation()))
+                        + " slot=" + slot);
+        bot.getBotCooldowns().set(EnderPearlBehavior.COOLDOWN_KEY,
+                EnderPearlBehavior.COOLDOWN_TICKS, bot.getAliveTicks());
         return true;
     }
 

--- a/TerminatorPlus-Plugin/src/main/java/net/nuggetmc/tplus/bot/combat/PlayerLikeActionController.java
+++ b/TerminatorPlus-Plugin/src/main/java/net/nuggetmc/tplus/bot/combat/PlayerLikeActionController.java
@@ -151,7 +151,8 @@ public final class PlayerLikeActionController {
 
     public boolean blocksCombatAction() {
         return switch (state) {
-            case USING_CONSUMABLE, DRINKING_POTION, THROWING_PROJECTILE, PLACING_BLOCK, USING_PEARL -> true;
+            case USING_CONSUMABLE, DRINKING_POTION, THROWING_PROJECTILE, PLACING_BLOCK,
+                    USING_WIND_CHARGE, USING_PEARL -> true;
             default -> false;
         };
     }

--- a/TerminatorPlus-Plugin/src/main/java/net/nuggetmc/tplus/bot/combat/TridentBehavior.java
+++ b/TerminatorPlus-Plugin/src/main/java/net/nuggetmc/tplus/bot/combat/TridentBehavior.java
@@ -22,7 +22,8 @@ public final class TridentBehavior {
     private static final int RELEASE_COOLDOWN = 45;
     public static final double MIN_DISTANCE = 5.0;
     public static final double MAX_DISTANCE = 30.0;
-    public static final double MELEE_FALLBACK_DISTANCE = 5.0;
+    /** A held trident still uses normal player melee reach; ranged use starts at 5 blocks. */
+    public static final double MELEE_FALLBACK_DISTANCE = MeleeBehavior.ATTACK_RANGE;
     private static final double THROW_BASE_SPEED = 2.5;
     private static final double THROW_MOMENTUM_BONUS = 1.4;
 

--- a/TerminatorPlus-Plugin/src/main/java/net/nuggetmc/tplus/bot/combat/WindChargeBehavior.java
+++ b/TerminatorPlus-Plugin/src/main/java/net/nuggetmc/tplus/bot/combat/WindChargeBehavior.java
@@ -18,6 +18,7 @@ public final class WindChargeBehavior {
 
     // Shared with deliberate offensive wind-charge plays.
     public static final String COOLDOWN_KEY = "windcharge";
+    public static final int COOLDOWN_TICKS = 55;
 
     // -- Self-propulsion wind charge --
     public static final String BOOST_COOLDOWN_KEY = "windcharge_boost";

--- a/TerminatorPlus-Plugin/src/main/java/net/nuggetmc/tplus/bot/movement/MovementOutputApplier.java
+++ b/TerminatorPlus-Plugin/src/main/java/net/nuggetmc/tplus/bot/movement/MovementOutputApplier.java
@@ -152,7 +152,7 @@ public final class MovementOutputApplier {
                     output.facingAdjustment() * 0.35,
                     Math.min(output.urgency(), 0.35),
                     Math.max(output.holdPosition(), 0.45));
-            case THROWING_PROJECTILE, USING_PEARL, PLACING_BLOCK, MINING -> new MovementOutput(
+            case THROWING_PROJECTILE, USING_WIND_CHARGE, USING_PEARL, PLACING_BLOCK, MINING -> new MovementOutput(
                     output.forwardPressure() * 0.45,
                     output.strafePressure() * 0.50,
                     0.0,

--- a/TerminatorPlus-Plugin/src/test/java/net/nuggetmc/tplus/bot/combat/CombatBoundarySpecTest.java
+++ b/TerminatorPlus-Plugin/src/test/java/net/nuggetmc/tplus/bot/combat/CombatBoundarySpecTest.java
@@ -1,0 +1,52 @@
+package net.nuggetmc.tplus.bot.combat;
+
+import net.nuggetmc.tplus.bot.loadout.Cooldowns;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Executable policy checks for the combat-fix specification.
+ * World-dependent behavior is covered by the Paper runtime harness.
+ */
+class CombatBoundarySpecTest {
+
+    @Test
+    void normalMeleeAcceptsThreePointFiveBlocksButNotBeyond() {
+        assertEquals(3.5, MeleeBehavior.ATTACK_RANGE);
+        assertTrue(3.5 <= MeleeBehavior.ATTACK_RANGE);
+        assertFalse(3.5001 <= MeleeBehavior.ATTACK_RANGE);
+    }
+
+    @Test
+    void tridentMeleeFallbackUsesNormalMeleeBoundary() {
+        assertEquals(MeleeBehavior.ATTACK_RANGE, TridentBehavior.MELEE_FALLBACK_DISTANCE);
+    }
+
+    @Test
+    void interceptWindowIsClosedAndOrdinaryRangeIsOutsideIt() {
+        assertFalse(ComboBehavior.isInterceptRange(29.99));
+        assertTrue(ComboBehavior.isInterceptRange(30.0));
+        assertTrue(ComboBehavior.isInterceptRange(35.0));
+        assertTrue(ComboBehavior.isInterceptRange(42.0));
+        assertFalse(ComboBehavior.isInterceptRange(42.01));
+        assertEquals(ComboBehavior.ComboType.WIND_PEARL_INTERCEPT,
+                ComboBehavior.typeForDistance(35.0));
+        assertEquals(ComboBehavior.ComboType.WIND_PEARL_ENGAGE,
+                ComboBehavior.typeForDistance(12.0));
+    }
+
+    @Test
+    void comboThrottleIsTenSecondsAndCooldownRegistryBlocksUntilExpiry() {
+        assertEquals(200, ComboBehavior.COOLDOWN_TICKS);
+
+        Cooldowns cooldowns = new Cooldowns();
+        cooldowns.set(EnderPearlBehavior.COOLDOWN_KEY, ComboBehavior.COOLDOWN_TICKS, 100);
+
+        assertFalse(cooldowns.ready(EnderPearlBehavior.COOLDOWN_KEY, 100));
+        assertFalse(cooldowns.ready(EnderPearlBehavior.COOLDOWN_KEY, 299));
+        assertTrue(cooldowns.ready(EnderPearlBehavior.COOLDOWN_KEY, 300));
+    }
+}


### PR DESCRIPTION
## What changed

- Retains the reviewed wind-charge/ender-pearl combat slice inspired by PR #11, implemented under the current combat/action-controller architecture.
- Adds direct-attack and mace line-of-sight checks, normalizes melee/trident reach, bounds the intercept window, and applies a 200-tick combo throttle.
- Adds focused JUnit coverage for the combat boundaries.
- Updates `CODEX.md` so `master` is the active source of truth.

## What is deliberately excluded

No PR #12 terrain-navigation code, API hooks, movement routing, or default-on configuration is included. The audit found that its strategy routed back to legacy movement instead of calling navigation, while bypassing legacy obstacle checks; it also mutated blocks directly.

Movement V2 is tracked separately in #17.

## Validation

- `./gradlew :TerminatorPlus-Plugin:test --tests net.nuggetmc.tplus.bot.combat.CombatBoundarySpecTest -q`
- `./gradlew build -q`
- `./gradlew checkMovementOnlyContract -q`
- `git diff --check`

The retained combat sources match the prior Paper runtime evidence; the PR12 integration is absent from this branch.