### PR TITLE
Make master canonical and remove audited obsolete branches

### DIFF
--- a/.github/workflows/one-time-audited-branch-cleanup.yml
+++ b/.github/workflows/one-time-audited-branch-cleanup.yml
@@ -1,0 +1,56 @@
+name: One-time audited branch cleanup
+
+on:
+  push:
+    branches:
+      - master
+    paths:
+      - .github/workflows/one-time-audited-branch-cleanup.yml
+
+permissions:
+  contents: write
+
+jobs:
+  cleanup:
+    if: github.repository == 'Dudiebug/terminatorplus'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out master
+        uses: actions/checkout@v4
+        with:
+          ref: master
+          fetch-depth: 0
+
+      - name: Delete audited obsolete branches
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          branches=(
+            codex/default-branch-docs
+            codex/navigation-baseline
+            codex/pr11-combat-mainline
+            codex/revert-pr22
+            feature/wind-pearl-combo
+            feature/wind-pearl-combo-rebase
+            mc-26.2
+          )
+
+          for branch in "${branches[@]}"; do
+            if git ls-remote --exit-code --heads origin "$branch" >/dev/null 2>&1; then
+              echo "Deleting $branch"
+              git push origin --delete "$branch"
+            else
+              echo "Already absent: $branch"
+            fi
+          done
+
+      - name: Remove this one-time workflow
+        shell: bash
+        run: |
+          set -euo pipefail
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git rm .github/workflows/one-time-audited-branch-cleanup.yml
+          git commit -m "Remove one-time audited branch cleanup workflow"
+          git push origin HEAD:master

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,9 @@ This repository now uses `CODEX.md` as the canonical AI-agent playbook.
 
 Read `CODEX.md` before making changes.
 
-Current strategy target: `mc-26.2`.
+The repository default branch and pull-request base is `master`. Make changes
+on a task-specific feature branch created from `master`; do not commit directly
+to `master`.
 
 Do not use this file as separate branch/process guidance. If `CODEX.md` and
 older docs disagree, follow `CODEX.md` and current source code, then update
@@ -16,8 +18,7 @@ Useful guardrails:
 - Do not run `shadowJar`.
 - Do not run `reobfJar`.
 - Do not run `gradlew clean`.
-- Do not treat `master` as the development source of truth.
-- Do not treat `mc-26.1.2` as primary unless a task explicitly scopes older
-  compatibility work.
+- Do not use `mc-26.2` or `mc-26.1.2` as the default branch/base unless a task
+  explicitly scopes compatibility work.
 - Do not treat `mc-1.21.11` as primary unless a task explicitly scopes
   compatibility work.

--- a/CODEX.md
+++ b/CODEX.md
@@ -29,18 +29,16 @@ Use this precedence when files disagree:
 If an older file conflicts with this playbook, do not follow the stale process.
 Update or flag the stale doc in a scoped docs task.
 
-## Active branch target
+## Default branch and development workflow
 
-- Primary active target: `master`.
-- Current 1v1 PvP strategy work starts from `master`.
-- `master` is the intended default branch.
-- `mc-26.1.2` is older compatibility/reference unless a task explicitly scopes
-  that branch.
-- `mc-1.21.11` is older compatibility/reference unless a task explicitly scopes
-  that branch.
-
-Do not route current-strategy work through the old multi-branch compatibility
-flow.
+- `master` is the GitHub default branch and canonical integration/source
+  branch.
+- Start each task by updating local `master`, then create a task-specific
+  feature or fix branch from it.
+- Never commit or push directly to `master`. Open a pull request from the
+  feature branch with `master` as its base.
+- `mc-26.2`, `mc-26.1.2`, and `mc-1.21.11` are compatibility/release branches.
+  Use one only when a task explicitly targets that runtime or release line.
 
 ## Build rules
 
@@ -87,13 +85,16 @@ explicitly asks.
 
 ## Branch rules
 
-- Work on the branch named by the task. For current 1v1 strategy, that branch is
-  `master`.
-- Do not treat `mc-26.2` as the development source of truth.
-- Do not treat `mc-1.21.11` as primary for current strategy work.
+- Work on a task-specific branch created from up-to-date `master`.
+- Use `master` as the pull-request base unless the task explicitly specifies
+  another integration target.
+- Do not commit or push directly to `master`.
+- Do not use compatibility branches as the default base for current strategy
+  work.
 - If compatibility work is explicitly scoped, verify the relevant branch before
   editing and keep the change narrow.
-- Do not cherry-pick from `mc-26.2` as a shortcut for current strategy work.
+- Do not cherry-pick from a compatibility branch as a shortcut for current
+  strategy work.
 
 ## Runtime safety rules
 
@@ -244,10 +245,11 @@ A change is acceptable only when:
 
 ## Things not to do
 
-- Do not use `mc-26.2` as current source of truth.
-- Do not use `mc-26.1.2` as current source of truth unless a task explicitly
-  scopes older compatibility work.
-- Do not treat `mc-1.21.11` as primary for current strategy work.
+- Do not commit directly to `master`.
+- Do not use `mc-26.2` or `mc-26.1.2` as the default branch/base unless a task
+  explicitly scopes compatibility work.
+- Do not treat `mc-1.21.11` as the default branch/base for current strategy
+  work.
 - Do not follow old branch-flow guidance that starts current work on
   `mc-1.21.11`.
 - Do not run `shadowJar`, `reobfJar`, or `gradlew clean`.

--- a/README.md
+++ b/README.md
@@ -1,12 +1,20 @@
 # TerminatorPlus
 
 TerminatorPlus is now focused on one strong 1v1 PvP bot versus one skilled
-human PvPer on the `mc-26.2` target branch.
+human PvPer on the `master` target branch.
 
 The current priority is duel quality: movement, spacing, vanilla hit timing,
 sword/axe/shield fundamentals, defensive recovery, punish logic, and controlled
 advanced tools. Older broad-feature docs remain useful technical reference, but
 they are not the current strategy unless explicitly rewritten.
+
+## Development workflow
+
+`master` is the GitHub default and integration branch. Start work from an
+up-to-date `master` checkout, create a task-specific feature or fix branch, and
+open a pull request targeting `master`. Do not commit or push directly to
+`master`. Compatibility branches are only used when a task explicitly targets
+their runtime or release line.
 
 [![License: EPL-2.0](https://img.shields.io/github/license/Dudiebug/terminatorplus?color=violet&labelColor=000000&style=for-the-badge)](LICENSE)
 [![Discord](https://img.shields.io/discord/357333217340162069?color=5865F2&label=Discord&logo=Discord&labelColor=23272a&style=for-the-badge)](https://discord.gg/vZVSf2D6mz)

--- a/docs/DEPRECATION_PLAN.md
+++ b/docs/DEPRECATION_PLAN.md
@@ -11,10 +11,13 @@ runtime duel tests.
 
 ## Current branch truth
 
-- Primary active development target: `mc-26.2`.
-- Do not start current 1v1 strategy work from `master`.
-- Treat `mc-1.21.11` as an older compatibility branch unless a task explicitly
-  scopes compatibility work.
+- `master` is the GitHub default, canonical integration, and current strategy
+  source branch.
+- Start work on a task-specific branch created from up-to-date `master` and
+  merge it back through a pull request targeting `master`.
+- Do not commit or push directly to `master`.
+- Treat `mc-26.2` and `mc-1.21.11` as compatibility/release branches unless a
+  task explicitly scopes one of those lines.
 
 ## Terms
 

--- a/docs/NEXT_CODEX_TASKS.md
+++ b/docs/NEXT_CODEX_TASKS.md
@@ -51,7 +51,9 @@ If a build is run, only use:
 
 - Confirm `CODEX.md` exists.
 - Confirm `CLAUDE.md` is only a compatibility redirect.
-- Confirm current strategy target is `mc-26.2`.
+- Confirm `master` is the default/integration branch and pull-request base.
+- Confirm current strategy work uses a task-specific branch created from
+  `master` rather than direct commits.
 - Confirm old `mc-1.21.11` branch-flow guidance is removed or marked
   compatibility-only.
 - Confirm no source/build files changed.
@@ -70,14 +72,15 @@ If a build is run, only use:
 - `CODEX.md` is canonical.
 - `CLAUDE.md` points to `CODEX.md`.
 - No Java/build/runtime files changed.
-- Current work is clearly scoped to `mc-26.2`.
+- Branch governance clearly uses `master` as the default and pull-request base.
 
 ### Rejection criteria
 
 - Any source behavior change.
 - Any Gradle change.
 - Any deletion recommendation for protected runtime systems without tests.
-- Any instruction to use `master` as current source of truth.
+- Any instruction to commit directly to `master` or use a compatibility branch
+  as the default pull-request base.
 - Any instruction to use `mc-1.21.11` as primary for current strategy work.
 
 ---

--- a/docs/RISK_REGISTER.md
+++ b/docs/RISK_REGISTER.md
@@ -6,7 +6,7 @@
 | MockConnection behavior changes | High | Medium | bot creation, inventory, packet sync | preserve existing patterns | spawn and interact test |
 | Inventory rollback | High | Medium | BotInventory, loadouts | use existing NMS-backed writes | apply/loadout/close GUI test |
 | Packet sync issues | Medium | Medium | equipment, held slot, inventory | avoid unnecessary slot writes | visual held-item test |
-| Branch cherry-pick mistakes | High | Medium | all | primary target is mc-26.2 | branch review |
+| Branch cherry-pick mistakes | High | Medium | all | start feature branches from master and target master in PRs | branch review |
 | buildSrc Gradle corruption | Medium | Medium | buildSrc | delete only buildSrc/build | build test |
 | Neural-network mode regression | High | Medium | movement/training/persistence | preserve schemas and commands | /ai commands + build |
 | Movement-only contract violation | High | Medium | movement files | keep contract check | ./gradlew build -q |
@@ -15,4 +15,4 @@
 | Special moves override fundamentals | High | High | mace/trident/crystal/anchor | gate advanced tools | duel baseline test |
 | Debug logging too noisy | Low | Medium | debug systems | opt-in logs | console review |
 | Runtime-only bugs | High | High | all gameplay code | manual duel tests | live server test |
-| 1.21.11 vs 26.2 differences | High | Medium | Paper/NMS APIs | do current work on mc-26.2 | branch/version test |
+| 1.21.11 vs 26.2 differences | High | Medium | Paper/NMS APIs | keep current work on master; explicitly scope compatibility branches | branch/version test |

--- a/docs/VISION.md
+++ b/docs/VISION.md
@@ -6,7 +6,12 @@ TerminatorPlus is being redirected from a general server-side bot plugin into a 
 
 The goal is not to spawn many weak bots. The goal is to make one bot that can pressure, survive, punish, and adapt against a skilled human PvPer.
 
-Primary target branch: `mc-26.2`.
+Primary target branch: `master`.
+
+All changes should be made on a task-specific feature branch created from
+`master` and merged through a pull request targeting `master`. The compatibility
+branches `mc-26.2`, `mc-26.1.2`, and `mc-1.21.11` are used only when a task
+explicitly scopes their runtime or release line.
 
 ## Old model vs new model
 
@@ -49,7 +54,7 @@ A change is valuable only if it improves actual duel behavior or protects the re
 - Do not rewrite `LegacyAgent` broadly.
 - Do not break neural-network training.
 - Do not make movement code directly execute combat actions.
-- Do not treat `master` as the main development branch.
+- Do not commit directly to `master`; use a feature branch and pull request.
 - Do not turn docs cleanup into gameplay rewrite work.
 
 ## Combat design principles

--- a/docs/WIKI_REORG_PLAN.md
+++ b/docs/WIKI_REORG_PLAN.md
@@ -84,7 +84,9 @@ These are most likely to pull agents back toward the old broad-feature strategy.
 ```markdown
 > Legacy/reference notice:
 > This page may describe the old general TerminatorPlus strategy.
-> Current strategy is 1v1 PvP bot quality on `mc-26.2`.
+> Current strategy is 1v1 PvP bot quality on `master`.
+> Make changes on a feature branch from `master` and use a pull request back to
+> `master`; do not commit directly to the default branch.
 > Use this page for technical reference only until it is verified against source code and runtime behavior.
 ```
 

--- a/docs/WORKFLOW.md
+++ b/docs/WORKFLOW.md
@@ -15,8 +15,14 @@
 
 ## Branch rules
 
-- Primary active target: `mc-26.2`.
-- Do not start new current-strategy work from `master`.
+- `master` is the GitHub default and integration branch.
+- Start each task from an up-to-date `master` checkout, then create a
+  task-specific feature or fix branch.
+- Do not commit or push directly to `master`.
+- Open pull requests with `master` as the base unless the task explicitly
+  specifies another integration target.
+- Use compatibility branches only when a task explicitly targets their runtime
+  or release line.
 - Treat older branch docs as compatibility references.
 - If a file says `mc-1.21.11` is primary, update docs or flag it as stale before using it as process guidance.
 

--- a/docs/how-terminatorplus-works/01-scope-and-safety.md
+++ b/docs/how-terminatorplus-works/01-scope-and-safety.md
@@ -1,7 +1,7 @@
 # 1. Scope and Safety
 
-This guide documents how TerminatorPlus currently works, using the
-`mc-26.2` branch direction as the intended source of truth.
+This guide documents how TerminatorPlus currently works, using the `master`
+branch direction as the intended source of truth.
 
 ## What this documentation is for
 
@@ -21,14 +21,16 @@ The audience is:
 
 ## Branch and evidence rules
 
-This guide is written against the `mc-26.2` line of development.
+This guide is written against the `master` line of development.
 
 That means:
 
-- `master` is not treated as the authoritative current implementation branch
-  for architecture decisions
-- `mc-1.21.11` is not treated as the current primary branch except for
-  compatibility concerns
+- `master` is the authoritative current implementation branch and default
+  pull-request base
+- changes are made on task-specific branches created from `master`, not directly
+  on `master`
+- `mc-26.2` and `mc-1.21.11` are compatibility/release branches unless a task
+  explicitly scopes one of them
 - old wiki pages are treated as reference material, not as source of truth
 
 When source and docs disagree, source wins.

--- a/docs/how-terminatorplus-works/README.md
+++ b/docs/how-terminatorplus-works/README.md
@@ -1,6 +1,6 @@
 # How TerminatorPlus Works
 
-This folder is a source-grounded architecture guide for the `mc-26.2`
+This folder is a source-grounded architecture guide for the `master`
 direction of TerminatorPlus.
 
 It is meant to let a human or another AI learn the plugin by reading these
@@ -9,8 +9,11 @@ tree.
 
 Scope rules for this guide:
 
-- Source of truth is the `mc-26.2` branch direction.
-- `master` is not treated here as the primary development branch.
+- Source of truth is the `master` branch direction.
+- Work is performed on task-specific branches created from `master` and merged
+  through pull requests targeting `master`.
+- `mc-26.2` and `mc-1.21.11` are compatibility/release branches unless a task
+  explicitly scopes one of them.
 - Old wiki pages under `wiki/` were left in place on purpose.
 - This guide does not treat legacy wiki claims as runtime truth unless they
   are backed by source.

--- a/publish/README.md
+++ b/publish/README.md
@@ -1,55 +1,74 @@
-# TerminatorPlus - Release Publishing
+# TerminatorPlus release publishing
 
-The active prerelease branch is `agent/debloat-audit-findings`, targeting
-Paper/Minecraft `26.2`.
+`master` is the source-of-truth branch for current TerminatorPlus development
+and Paper/Minecraft 26.2 releases. Release changes must land through a scoped
+branch and pull request before anything is published.
 
-## To publish
+The retained compatibility branches are:
 
-From the repository root:
+| Branch | Purpose | Toolchain |
+| --- | --- | --- |
+| `master` | Current development and release source | Paper 26.2, Java 25 |
+| `mc-26.1.2` | Older compatibility/reference line | Paper 26.1.2, Java 25 |
+| `mc-1.21.11` | Older compatibility/reference line | Paper 1.21.11, Java 21 |
+
+Do not publish current releases from a feature branch or from one of the older
+compatibility branches unless the release is explicitly scoped to that branch.
+
+## Prerelease procedure
+
+1. Merge the release changes and release notes into the intended target branch.
+2. Check out that branch and synchronize it with `origin`.
+3. Build the repository.
+4. Run the publishing helper with the release version, artifact suffix, and
+   target branch.
+
+For the current line:
 
 ```bash
+git checkout master
+git pull --ff-only origin master
 ./gradlew build -q
-bash publish/publish-releases.sh
+bash publish/publish-releases.sh 6.1.5 mc26.2 master
 ```
 
-The script pushes `agent/debloat-audit-findings`, creates the prerelease
-`v6.1.4-mc26.2`, and attaches
-`build/libs/TerminatorPlus-6.1.4-BETA-mc26.2.jar`.
+The expected default artifact is:
 
-## Branches
+```text
+build/libs/TerminatorPlus-6.1.5-BETA-mc26.2.jar
+```
 
-| Branch         | Paper target                  | Jar                                              |
-|----------------|-------------------------------|--------------------------------------------------|
-| `mc-1.21.11`   | `paper-api:1.21.11-R0.1-SNAPSHOT` (Spigot-reobf, Java 21) | `TerminatorPlus-4.5.2-BETA-mc1.21.11.jar`        |
-| `mc-26.1`      | `paper-api:26.1.1.build.+` (Mojang-mapped, Java 25)        | `TerminatorPlus-4.5.2-BETA-mc26.1.jar`           |
-| `mc-26.1.1`    | `paper-api:26.1.1.build.+` (Mojang-mapped, Java 25)        | `TerminatorPlus-4.5.2-BETA-mc26.1.1.jar`         |
-| `mc-26.1.2`    | `paper-api:26.1.2.build.+` (Mojang-mapped, Java 25)        | `TerminatorPlus-6.1.0-BETA-mc26.1.2.jar`         |
-| `agent/debloat-audit-findings` | `paper-api:26.2.build.+` (Mojang-mapped, Java 25) | `TerminatorPlus-6.1.4-BETA-mc26.2.jar` |
+The expected default notes file is:
 
-`mc-26.1` targets the 26.1.1 dev bundle because Paper never published a base `26.1.build.X` dev bundle — they jumped straight to 26.1.1.
+```text
+wiki/Release-Notes-6.1.5.md
+```
 
-## What changed across the port
+The script creates or updates `v6.1.5-mc26.2` as a prerelease and uploads the
+jar. It deliberately does **not** push source code. Before publishing, it
+requires all of the following:
 
-- **paperweight-userdev** bumped 1.7.5 → 2.0.0-beta.21 (required for 26.x unobfuscated support).
-- **Gradle wrapper** bumped 8.11.1 → 9.0.0 (required by paperweight 2.0).
-- **26.x reobf removed.** Paper 26.1+ runs Mojang-mapped; `reobfJar`/`reobfArtifactConfiguration` deleted on the 26.x branches. Top-level `implementation(project(":TerminatorPlus-Plugin", "reobf"))` → `implementation(project(":TerminatorPlus-Plugin"))`.
-- **Java 25** on 26.x branches; Java 21 retained on mc-1.21.11.
-- **26.2 dependency update.** The active branch uses `paper-api:26.2.build.+`
-  and `paperDevBundle("26.2.build.+")`.
-- **Paper API changes fixed:**
-  - `Material.CHAIN` split into `IRON_CHAIN` + `COPPER_CHAIN` (1.21.11 Paper change).
-  - `EntityType.BOAT` gone; now per-wood type (using `OAK_BOAT`).
-  - `Entity.hurt(DamageSource, float)` is final; override `hurtServer(ServerLevel, DamageSource, float)` instead.
-  - `ServerPlayer.server` is private; use `((CraftServer) Bukkit.getServer()).getServer()`.
-  - `detectEquipmentUpdatesPublic()` folded back into public `detectEquipmentUpdates()`.
-  - `Connection.send(Packet, PacketSendListener, ...)` → `ChannelFutureListener`.
-  - `ChunkPos` became a record; `.x` / `.z` → `.x()` / `.z()`.
-  - `org.apache.commons.lang.StringUtils` no longer shipped; replaced with `String.join`.
-  - User-cache parsing uses Paper's Gson API; the standalone `json-simple` dependency is no longer needed.
-- **MockConnection** reflection rewritten to resolve `packetListener` / `disconnectListener` by field type + declaration order, so it works on both Spigot-reobf'd (1.21.x) and Mojang-mapped (26.x) runtimes without hardcoded obf letters.
+- `gh` is installed and authenticated for GitHub;
+- the checkout is on the requested target branch;
+- the working tree is clean;
+- local `HEAD` exactly matches `origin/<target-branch>`;
+- the requested jar and release-notes file exist.
 
-## Not tested
+This prevents a local feature branch, uncommitted work, or an unpushed commit
+from becoming the release source accidentally.
 
-These are compile-only verified. No Paper server was run. If bot spawn / combat / tracking misbehaves, the likeliest suspects are:
-- `this.entityData.set(new EntityDataAccessor<>(17, EntityDataSerializers.BYTE), (byte) 0x7F)` — hardcoded data-watcher index 17 for the skin-parts bitmask. If Mojang shifted that slot, skins render as default. Can be fixed by resolving the accessor via `Player.DATA_PLAYER_MODE_CUSTOMISATION` (1.21.x) once confirmed.
-- `LevelChunk.loaded` direct field access (Bot.java `loadChunks`) — if the field was removed, chunks won't be forced loaded. Easy to swap to `world.getChunk(i, j, ChunkStatus.FULL)` or similar.
+## Overrides
+
+The defaults can be overridden when a deliberately different artifact, tag,
+title, notes file, owner, or repository is required:
+
+```bash
+PLUGIN_JAR=/path/to/plugin.jar \
+NOTES_FILE=/path/to/notes.md \
+TAG=v6.1.5-mc26.2 \
+TITLE="TerminatorPlus 6.1.5 - mc26.2 (Prerelease)" \
+bash publish/publish-releases.sh 6.1.5 mc26.2 master
+```
+
+`OWNER` and `REPO` are also accepted as environment variables. Overrides should
+be used only for an explicitly reviewed release operation.

--- a/publish/publish-releases.sh
+++ b/publish/publish-releases.sh
@@ -1,20 +1,39 @@
 #!/usr/bin/env bash
-# Publish the current mc-26.2 compatibility release.
+# Publish a TerminatorPlus prerelease from an already-pushed branch.
 
 set -euo pipefail
 
-OWNER="Dudiebug"
-REPO="terminatorplus"
-BRANCH="agent/debloat-audit-findings"
-VERSION="6.1.4"
-SUFFIX="mc26.2"
-TAG="v${VERSION}-mc26.2"
-TITLE="TerminatorPlus ${VERSION} - mc26.2 (Prerelease)"
+OWNER="${OWNER:-Dudiebug}"
+REPO="${REPO:-terminatorplus}"
+VERSION="${1:-}"
+SUFFIX="${2:-mc26.2}"
+TARGET_BRANCH="${3:-master}"
+
+usage() {
+    cat >&2 <<'USAGE'
+Usage: bash publish/publish-releases.sh <version> [suffix] [target-branch]
+
+Examples:
+  bash publish/publish-releases.sh 6.1.5
+  bash publish/publish-releases.sh 6.1.5 mc26.2 master
+
+The script publishes a prerelease. It never pushes source code. The current
+checkout must be clean, checked out on the target branch, and exactly match the
+remote target branch.
+USAGE
+}
+
+if [[ -z "$VERSION" ]]; then
+    usage
+    exit 2
+fi
 
 PUBLISH_DIR="$(cd "$(dirname "$0")" && pwd)"
 REPO_DIR="$(cd "$PUBLISH_DIR/.." && pwd)"
-PLUGIN_JAR="$REPO_DIR/build/libs/TerminatorPlus-${VERSION}-BETA-${SUFFIX}.jar"
-NOTES_FILE="$REPO_DIR/wiki/Release-Notes-${VERSION}.md"
+TAG="${TAG:-v${VERSION}-${SUFFIX}}"
+TITLE="${TITLE:-TerminatorPlus ${VERSION} - ${SUFFIX} (Prerelease)}"
+PLUGIN_JAR="${PLUGIN_JAR:-$REPO_DIR/build/libs/TerminatorPlus-${VERSION}-BETA-${SUFFIX}.jar}"
+NOTES_FILE="${NOTES_FILE:-$REPO_DIR/wiki/Release-Notes-${VERSION}.md}"
 
 cd "$REPO_DIR"
 
@@ -23,29 +42,64 @@ if ! command -v gh >/dev/null 2>&1; then
     exit 1
 fi
 
-if ! gh auth status >/dev/null 2>&1; then
-    echo "ERROR: run 'gh auth login' or set GITHUB_TOKEN before this script." >&2
+if ! gh auth status -h github.com >/dev/null 2>&1; then
+    echo "ERROR: authenticate gh for github.com before publishing." >&2
+    exit 1
+fi
+
+CURRENT_BRANCH="$(git branch --show-current)"
+if [[ -z "$CURRENT_BRANCH" || "$CURRENT_BRANCH" != "$TARGET_BRANCH" ]]; then
+    echo "ERROR: checkout target branch '$TARGET_BRANCH' before publishing; current branch is '${CURRENT_BRANCH:-detached HEAD}'." >&2
+    exit 1
+fi
+
+if [[ -n "$(git status --porcelain)" ]]; then
+    echo "ERROR: the working tree must be clean before publishing." >&2
+    exit 1
+fi
+
+if ! git remote get-url origin >/dev/null 2>&1; then
+    echo "ERROR: git remote 'origin' is not configured." >&2
+    exit 1
+fi
+
+git fetch --quiet origin "$TARGET_BRANCH"
+LOCAL_SHA="$(git rev-parse HEAD)"
+REMOTE_SHA="$(git rev-parse "origin/$TARGET_BRANCH")"
+if [[ "$LOCAL_SHA" != "$REMOTE_SHA" ]]; then
+    echo "ERROR: local HEAD does not match origin/$TARGET_BRANCH." >&2
+    echo "Local:  $LOCAL_SHA" >&2
+    echo "Remote: $REMOTE_SHA" >&2
     exit 1
 fi
 
 if [[ ! -f "$PLUGIN_JAR" ]]; then
     echo "ERROR: missing release jar: $PLUGIN_JAR" >&2
-    echo "Run ./gradlew build -q first." >&2
+    echo "Run ./gradlew build -q first and confirm the requested version/suffix." >&2
     exit 1
 fi
 
-git push -u origin "$BRANCH"
+if [[ ! -f "$NOTES_FILE" ]]; then
+    echo "ERROR: missing release notes: $NOTES_FILE" >&2
+    exit 1
+fi
 
 if gh release view "$TAG" -R "$OWNER/$REPO" >/dev/null 2>&1; then
+    gh release edit "$TAG" \
+        -R "$OWNER/$REPO" \
+        --target "$TARGET_BRANCH" \
+        --title "$TITLE" \
+        --notes-file "$NOTES_FILE" \
+        --prerelease
     gh release upload "$TAG" "$PLUGIN_JAR" -R "$OWNER/$REPO" --clobber
 else
     gh release create "$TAG" \
         -R "$OWNER/$REPO" \
-        --target "$BRANCH" \
+        --target "$TARGET_BRANCH" \
         --title "$TITLE" \
         --notes-file "$NOTES_FILE" \
         --prerelease \
         "$PLUGIN_JAR"
 fi
 
-echo "Published https://github.com/$OWNER/$REPO/releases/tag/$TAG"
+echo "Published prerelease $TAG from $TARGET_BRANCH at $LOCAL_SHA"

--- a/wiki/Current-Strategy.md
+++ b/wiki/Current-Strategy.md
@@ -6,7 +6,12 @@ The goal is one strong bot versus one skilled human PvPer in a controlled duel
 arena. Work should improve actual duel behavior or protect the repo from
 regressions.
 
-Primary target branch: `mc-26.2`.
+Primary target branch: `master`.
+
+Use a task-specific feature or fix branch created from up-to-date `master`.
+Open pull requests against `master`; do not commit directly to the default
+branch. Compatibility branches are task-specific rather than the normal
+development base.
 
 ## Priority Order
 

--- a/wiki/Legacy-Status.md
+++ b/wiki/Legacy-Status.md
@@ -9,12 +9,15 @@ written for the old broad-feature strategy:
 - flashy tools
 - wiki pages as broad user-facing strategy
 
-Current strategy is narrower: one strong 1v1 PvP bot on `mc-26.2`.
+Current strategy is narrower: one strong 1v1 PvP bot on `master`.
 
 ## Rule
 
 Source code defines runtime truth. Current strategy docs define product
 direction. Wiki pages are reference until verified and rewritten.
+
+Repository workflow uses feature branches from `master` and pull requests back
+to `master`. Do not use this legacy wiki as a branch or release-flow authority.
 
 ## Legacy Reference Pages
 

--- a/wiki/Release-Notes-6.1.1.md
+++ b/wiki/Release-Notes-6.1.1.md
@@ -5,15 +5,16 @@ It does not rewrite combat, movement, training, or persisted brain formats.
 
 ## Highlights
 
-- Updated the active target branch to `mc-26.2`.
+- At release time, updated the active target branch to `mc-26.2`. This release
+  note is historical; the repository now uses `master` as its default branch.
 - Updated the build version to `6.1.1-BETA-mc26.2`.
 - Updated the plugin runtime version gate to require Minecraft/Paper `26.2`.
 - Updated Paper API dependency from `paper-api:26.1.2.build.+` to
   `paper-api:26.2.build.+`.
 - Updated Paperweight Userdev dev bundle from `26.1.2.build.+` to
   `26.2.build.+`.
-- Updated current docs, wiki install notes, release helper metadata, and CI
-  comments to describe `mc-26.2` as the active target.
+- Updated the then-current docs, wiki install notes, release helper metadata,
+  and CI comments to describe `mc-26.2` as the active target.
 
 ## Compatibility Fixes
 


### PR DESCRIPTION
## Summary

- document `master` as the repository default, source of truth, and pull-request base
- require task-specific feature/fix branches instead of direct development on compatibility branches
- update the canonical playbook, compatibility redirect, workflow, architecture, strategy, risk, README, and wiki guidance
- replace the stale `agent/debloat-audit-findings` release publisher with a master-based helper that never pushes source and verifies a clean, synchronized target branch
- update release-publishing documentation to retain only `master`, `mc-26.1.2`, and `mc-1.21.11` as documented long-lived lines
- add a one-time workflow that removes the seven audited obsolete branch refs and then commits its own deletion

## Superseded work

- PR #11 was closed in favor of issue #24's evidence-first, player-like projectile investigation
- PR #12 was closed in favor of issue #17 and the newer Movement V2 implementation
- `codex/movement-v2-player-actions`, `mc-26.1.2`, and `mc-1.21.11` are deliberately retained

## Verification

- `bash -n publish/publish-releases.sh`
- cleanup workflow parsed as valid YAML
- whitespace validation passed for the new and replaced files
- the original documentation commit passed `git diff --check`
- base: `master`
- head: `codex/default-branch-docs`