### PR TITLE
Reorganize command surface and prepare 6.2.2

### DIFF
--- a/TerminatorPlus-API/src/main/java/net/nuggetmc/tplus/api/agent/legacyagent/EnumTargetGoal.java
+++ b/TerminatorPlus-API/src/main/java/net/nuggetmc/tplus/api/agent/legacyagent/EnumTargetGoal.java
@@ -1,6 +1,7 @@
 package net.nuggetmc.tplus.api.agent.legacyagent;
 
 import java.util.HashMap;
+import java.util.Locale;
 import java.util.Map;
 
 public enum EnumTargetGoal {
@@ -39,7 +40,8 @@ public enum EnumTargetGoal {
     }
 
     public static EnumTargetGoal from(String name) {
-        return VALUES.get(name);
+        if (name == null) return null;
+        return VALUES.get(name.toLowerCase(Locale.ROOT).replace("_", "").replace("-", ""));
     }
 
     public String description() {

--- a/TerminatorPlus-Plugin/src/main/java/net/nuggetmc/tplus/bot/gui/BotManagementUI.java
+++ b/TerminatorPlus-Plugin/src/main/java/net/nuggetmc/tplus/bot/gui/BotManagementUI.java
@@ -509,11 +509,11 @@ public final class BotManagementUI implements Listener {
         put(session, 17, Material.BOOK, "Help / plugin info", UiAction.OPEN_HELP, null,
                 "Show existing help and plugin information");
         put(session, 19, Material.ENDER_PEARL, "Gather all", UiAction.BOT_GATHER, null,
-                "/bot gather");
+                "/bot move gather");
         put(session, 20, Material.COMPASS, "Circular scatter", UiAction.BOT_SCATTER, null,
-                "/bot scatter (default radius)");
+                "/bot move scatter (default radius)");
         put(session, 21, Material.PAPER, "Count bots", UiAction.BOT_COUNT, null,
-                "/bot count");
+                "/bot inspect list");
     }
 
     private void renderBots(Session session) {
@@ -562,17 +562,17 @@ public final class BotManagementUI implements Listener {
             return;
         }
         put(session, 11, Material.PAPER, "Bot info", UiAction.BOT_INFO, bot.getBotName(),
-                "/bot info " + bot.getBotName());
+                "/bot inspect info " + bot.getBotName());
         put(session, 12, Material.REDSTONE, "AI info", UiAction.AI_INFO, bot.getBotName(),
-                "/ai info " + bot.getBotName());
+                "/ai inspect info " + bot.getBotName());
         put(session, 13, Material.DIAMOND_SWORD, "Weapon status", UiAction.BOT_WEAPONS, bot.getBotName(),
-                "/bot weapons " + bot.getBotName());
+                "/bot inspect weapons " + bot.getBotName());
         put(session, 14, Material.CHEST, "Edit inventory", UiAction.BOT_INVENTORY, bot.getBotName(),
-                "/bot inventory " + bot.getBotName());
+                "/bot equipment inventory " + bot.getBotName());
         put(session, 15, Material.OBSERVER, "Combat debug on", UiAction.BOT_COMBAT_DEBUG,
-                bot.getBotName() + " on", "/bot combatdebug " + bot.getBotName() + " on");
+                bot.getBotName() + " on", "/bot debug combat " + bot.getBotName() + " on");
         put(session, 16, Material.BARRIER, "Combat debug off", UiAction.BOT_COMBAT_DEBUG,
-                bot.getBotName() + " off", "/bot combatdebug " + bot.getBotName() + " off");
+                bot.getBotName() + " off", "/bot debug combat " + bot.getBotName() + " off");
         put(session, 17, Material.SHULKER_BOX, "Apply loadout...", UiAction.BOT_LOADOUT, null,
                 "Enter loadout [bot-name]");
     }
@@ -602,18 +602,18 @@ public final class BotManagementUI implements Listener {
                 "Enter a radius; command validates it");
         put(session, 13, Material.TOTEM_OF_UNDYING,
                 "Respawn: " + (respawnEnabled ? "enabled" : "disabled"), UiAction.BOT_RESPAWN, null,
-                "/bot respawn");
+                "/bot settings auto-respawn");
         put(session, 14, Material.LIME_DYE, "Enable respawn", UiAction.BOT_RESPAWN, "true",
-                "/bot respawn true");
+                "/bot settings auto-respawn true");
         put(session, 15, Material.RED_DYE, "Disable respawn", UiAction.BOT_RESPAWN, "false",
-                "/bot respawn false");
+                "/bot settings auto-respawn false");
         put(session, 16, Material.FEATHER,
                 "Movement V2: " + (movementV2Enabled ? "enabled" : "disabled"), UiAction.BOT_MOVEMENT_V2, "status",
-                "/bot movementv2 status");
+                "/bot settings movement-v2 status");
         put(session, 17, Material.LIME_WOOL, "Enable Movement V2", UiAction.BOT_MOVEMENT_V2, "on",
-                "/bot movementv2 on");
+                "/bot settings movement-v2 on");
         put(session, 18, Material.RED_WOOL, "Disable Movement V2", UiAction.BOT_MOVEMENT_V2, "off",
-                "/bot movementv2 off");
+                "/bot settings movement-v2 off");
     }
 
     private void renderAi(Session session) {
@@ -632,7 +632,7 @@ public final class BotManagementUI implements Listener {
             put(session, 15, Material.WRITABLE_BOOK, "Save selected brain", UiAction.AI_BRAIN_SAVE,
                     bot == null ? null : bot.getBotName(), "/ai brain save <selected bot>");
             put(session, 19, Material.REDSTONE, "AI info (selected)", UiAction.AI_INFO,
-                    bot == null ? null : bot.getBotName(), "/ai info <selected bot>");
+                    bot == null ? null : bot.getBotName(), "/ai inspect info <selected bot>");
         } else {
             put(session, 15, Material.WRITABLE_BOOK, "Save brain...", UiAction.AI_BRAIN_SAVE_INPUT, null,
                     "Enter optional bot name");
@@ -651,9 +651,9 @@ public final class BotManagementUI implements Listener {
 
     private void renderCombat(Session session) {
         put(session, 10, Material.DIAMOND_SWORD, "Weapons (all)", UiAction.BOT_WEAPONS, null,
-                "/bot weapons");
+                "/bot inspect weapons");
         put(session, 11, Material.IRON_SWORD, "Weapons (selected)", UiAction.BOT_WEAPONS,
-                selectedName(session), "/bot weapons <selected bot>");
+                selectedName(session), "/bot inspect weapons <selected bot>");
         put(session, 12, Material.CHEST, "Give item...", UiAction.BOT_GIVE, null,
                 "item [bot-name] [slot]");
         put(session, 13, Material.BRICKS, "Placement material...", UiAction.BOT_PLACE, null,
@@ -675,45 +675,45 @@ public final class BotManagementUI implements Listener {
         String selectedName = selectedName(session);
         put(session, 21, Material.CHEST, selectedName == null ? "Open inventory..." : "Open selected inventory",
                 selectedName == null ? UiAction.BOT_INVENTORY_INPUT : UiAction.BOT_INVENTORY,
-                selectedName, selectedName == null ? "Enter bot-name" : "/bot inventory <selected bot>");
+                selectedName, selectedName == null ? "Enter bot-name" : "/bot equipment inventory <selected bot>");
         put(session, 22, Material.PAPER, "Count bots", UiAction.BOT_COUNT, null,
-                "/bot count");
+                "/bot inspect list");
     }
 
     private void renderAdmin(Session session) {
         put(session, 10, Material.TNT, "Reset all bots", UiAction.BOT_RESET, null,
                 "Confirmation and permission recheck required");
         put(session, 11, Material.LIME_DYE, "Mob targeting on", UiAction.BOT_SETTINGS, "mobtarget true",
-                "/bot settings mobtarget true");
+                "/bot settings target-mobs true");
         put(session, 12, Material.RED_DYE, "Mob targeting off", UiAction.BOT_SETTINGS, "mobtarget false",
-                "/bot settings mobtarget false");
+                "/bot settings target-mobs false");
         put(session, 13, Material.LIME_DYE, "Player-list on", UiAction.BOT_SETTINGS, "addplayerlist true",
-                "/bot settings addplayerlist true");
+                "/bot settings show-in-player-list true");
         put(session, 14, Material.RED_DYE, "Player-list off", UiAction.BOT_SETTINGS, "addplayerlist false",
-                "/bot settings addplayerlist false");
+                "/bot settings show-in-player-list false");
         put(session, 15, Material.COMPASS, "Set target goal...", UiAction.BOT_SETTINGS_INPUT, null,
-                "setgoal value");
+                "combat-goal value");
         put(session, 16, Material.BEACON, "Set region...", UiAction.BOT_SETTINGS_REGION_INPUT, null,
-                "region bounds and weights");
+                "target-region bounds and weights");
         put(session, 17, Material.BARRIER, "Clear region", UiAction.BOT_SETTINGS_REGION_CLEAR, null,
                 "Confirmation required");
         put(session, 18, Material.COMPARATOR, "Debug expression...", UiAction.BOT_DEBUG, null,
-                "Existing debugger expression");
+                "Enter a behavior expression");
         put(session, 19, Material.OBSERVER, "Combat debug all on", UiAction.BOT_COMBAT_DEBUG, "all on",
-                "/bot combatdebug all on");
+                "/bot debug combat all on");
         put(session, 20, Material.REDSTONE_TORCH, "Combat debug all off", UiAction.BOT_COMBAT_DEBUG, "all off",
-                "/bot combatdebug all off");
+                "/bot debug combat all off");
         put(session, 21, Material.PAPER, "Combat debug args...", UiAction.BOT_COMBAT_DEBUG_INPUT, null,
                 "bot-name|all on|off");
     }
 
     private void renderEnvironment(Session session) {
         put(session, 10, Material.BOOK, "Environment help", UiAction.ENV_HELP, null,
-                "/botenvironment help");
+                "/bot environment");
         put(session, 11, Material.BOOK, "Block help", UiAction.ENV_HELP, "blocks",
-                "/botenvironment help blocks");
+                "/bot environment solid-block");
         put(session, 12, Material.BOOK, "Mob help", UiAction.ENV_HELP, "mobs",
-                "/botenvironment help mobs");
+                "/bot environment custom-mob");
         put(session, 13, Material.COMPASS, "Get material...", UiAction.ENV_GET_MATERIAL, null,
                 "x y z (relative values supported)");
         put(session, 14, Material.BRICKS, "Add solid...", UiAction.ENV_ADD_SOLID, null,
@@ -721,7 +721,7 @@ public final class BotManagementUI implements Listener {
         put(session, 15, Material.BARRIER, "Remove solid...", UiAction.ENV_REMOVE_SOLID, null,
                 "material or x y z");
         put(session, 16, Material.PAPER, "List solids", UiAction.ENV_LIST_SOLIDS, null,
-                "/botenvironment listSolids");
+                "/bot environment solid-block list");
         put(session, 17, Material.TNT, "Clear solids", UiAction.ENV_CLEAR_SOLIDS, null,
                 "Confirmation required");
         put(session, 18, Material.ZOMBIE_HEAD, "Add custom mob...", UiAction.ENV_ADD_CUSTOM_MOB, null,
@@ -729,13 +729,13 @@ public final class BotManagementUI implements Listener {
         put(session, 19, Material.BARRIER, "Remove custom mob...", UiAction.ENV_REMOVE_CUSTOM_MOB, null,
                 "entity type");
         put(session, 20, Material.PAPER, "List custom mobs", UiAction.ENV_LIST_CUSTOM_MOBS, null,
-                "/botenvironment listCustomMobs");
+                "/bot environment custom-mob list");
         put(session, 21, Material.TNT, "Clear custom mobs", UiAction.ENV_CLEAR_CUSTOM_MOBS, null,
                 "Confirmation required");
         put(session, 22, Material.COMPARATOR, "Mob list type...", UiAction.ENV_MOB_LIST_TYPE, null,
                 "custom list mode");
         put(session, 23, Material.FEATHER, "Movement V2 status", UiAction.ENV_MOVEMENT_V2_STATUS, null,
-                "/botenvironment movementV2Status [bot-name]");
+                "/bot debug movement [bot-name]");
     }
 
     private void renderHelp(Session session) {
@@ -748,7 +748,7 @@ public final class BotManagementUI implements Listener {
         put(session, 13, Material.REDSTONE, "AI command help", UiAction.AI_HELP, null,
                 "/ai");
         put(session, 14, Material.GRASS_BLOCK, "Environment help", UiAction.ENV_HELP, null,
-                "/botenvironment help");
+                "/bot environment");
     }
 
     private void renderConfirmation(Session session) {
@@ -948,66 +948,66 @@ public final class BotManagementUI implements Listener {
         CANCEL(null, false, false, false, "Cancel"),
 
         BOT_HELP("bot info", false, false, false, "Bot help"),
-        BOT_CREATE("bot create", true, false, false, "Create bot"),
-        BOT_MULTI("bot multi", true, false, false, "Create multiple bots"),
-        BOT_RESPAWN("bot respawn", false, false, true, "Respawn"),
-        BOT_MOVEMENT_V2("bot movementv2", false, false, true, "Movement V2"),
-        BOT_GIVE("bot give", true, false, false, "Give item"),
-        BOT_PLACE("bot place", true, false, false, "Placement material"),
-        BOT_ARMOR("bot armor", true, false, false, "Armor"),
-        BOT_INFO("bot info", false, false, false, "Bot info"),
-        BOT_COUNT("bot count", false, false, false, "Count bots"),
-        BOT_RESET("bot reset", false, true, true, "Reset all bots"),
+        BOT_CREATE("bot spawn single", true, false, false, "Create bot"),
+        BOT_MULTI("bot spawn multiple", true, false, false, "Create multiple bots"),
+        BOT_RESPAWN("bot settings auto-respawn", false, false, true, "Respawn"),
+        BOT_MOVEMENT_V2("bot settings movement-v2", false, false, true, "Movement V2"),
+        BOT_GIVE("bot equipment give", true, false, false, "Give item"),
+        BOT_PLACE("bot settings placement-material", true, false, false, "Placement material"),
+        BOT_ARMOR("bot equipment armor", true, false, false, "Armor"),
+        BOT_INFO("bot inspect info", false, false, false, "Bot info"),
+        BOT_COUNT("bot inspect list", false, false, false, "Count bots"),
+        BOT_RESET("bot admin reset", false, true, true, "Reset all bots"),
         BOT_SETTINGS("bot settings", false, false, false, "Bot settings"),
         BOT_SETTINGS_INPUT("bot settings", true, false, false, "Bot settings"),
-        BOT_SETTINGS_REGION_INPUT("bot settings region", true, false, false, "Set region"),
-        BOT_SETTINGS_REGION_CLEAR("bot settings region clear", false, true, false, "Clear region"),
-        BOT_DEBUG("bot debug", true, false, true, "Debug expression"),
-        BOT_WEAPONS("bot weapons", false, false, false, "Weapon status"),
-        BOT_COMBAT_DEBUG("bot combatdebug", false, false, true, "Combat debug"),
-        BOT_COMBAT_DEBUG_INPUT("bot combatdebug", true, false, true, "Combat debug"),
-        BOT_GATHER("bot gather", false, false, false, "Gather"),
-        BOT_SCATTER("bot scatter", false, false, false, "Circular scatter"),
-        BOT_SCATTER_RADIUS("bot scatter", true, false, false, "Scatter radius"),
-        BOT_INVENTORY("bot inventory", false, false, false, "Inventory"),
-        BOT_INVENTORY_INPUT("bot inventory", true, false, false, "Inventory"),
+        BOT_SETTINGS_REGION_INPUT("bot settings target-region", true, false, false, "Set region"),
+        BOT_SETTINGS_REGION_CLEAR("bot settings target-region clear", false, true, false, "Clear region"),
+        BOT_DEBUG("bot debug behavior", true, false, true, "Debug expression"),
+        BOT_WEAPONS("bot inspect weapons", false, false, false, "Weapon status"),
+        BOT_COMBAT_DEBUG("bot debug combat", false, false, true, "Combat debug"),
+        BOT_COMBAT_DEBUG_INPUT("bot debug combat", true, false, true, "Combat debug"),
+        BOT_GATHER("bot move gather", false, false, false, "Gather"),
+        BOT_SCATTER("bot move scatter", false, false, false, "Circular scatter"),
+        BOT_SCATTER_RADIUS("bot move scatter", true, false, false, "Scatter radius"),
+        BOT_INVENTORY("bot equipment inventory", false, false, false, "Inventory"),
+        BOT_INVENTORY_INPUT("bot equipment inventory", true, false, false, "Inventory"),
         BOT_PRESET_SAVE("bot preset save", true, false, false, "Save preset"),
         BOT_PRESET_APPLY("bot preset apply", true, false, false, "Apply preset"),
         BOT_PRESET_LIST("bot preset list", false, false, false, "List presets"),
         BOT_PRESET_DELETE("bot preset delete", true, true, true, "Delete preset"),
-        BOT_LOADOUT("bot loadout", true, false, false, "Loadout"),
-        BOT_LOADOUT_MIX("bot loadoutmix", true, false, false, "Loadout mix"),
+        BOT_LOADOUT("bot equipment loadout", true, false, false, "Loadout"),
+        BOT_LOADOUT_MIX("bot equipment mixed-loadout", true, false, false, "Loadout mix"),
 
         AI_HELP("ai", false, false, false, "AI help"),
-        AI_RANDOM("ai random", true, false, false, "Random AI bots"),
-        AI_REINFORCEMENT("ai reinforcement", true, false, false, "Training session"),
-        AI_STOP("ai stop", false, true, false, "Stop training"),
+        AI_RANDOM("ai spawn random", true, false, false, "Random AI bots"),
+        AI_REINFORCEMENT("ai train reinforcement", true, false, false, "Training session"),
+        AI_STOP("ai train stop", false, true, false, "Stop training"),
         AI_BRAIN_STATUS("ai brain status", false, false, false, "Brain status"),
         AI_BRAIN_LOAD("ai brain load", false, false, false, "Load brain"),
         AI_BRAIN_SAVE("ai brain save", false, false, false, "Save brain"),
         AI_BRAIN_SAVE_INPUT("ai brain save", true, false, false, "Save brain"),
         AI_BRAIN_RESET("ai brain reset", false, true, false, "Reset brain"),
-        AI_MOVEMENT("ai movement", true, false, false, "Movement bots"),
+        AI_MOVEMENT("ai spawn movement", true, false, false, "Movement bots"),
         AI_EVALUATE("ai evaluate", false, false, false, "Evaluate"),
         AI_EVALUATE_INPUT("ai evaluate", true, false, false, "Evaluate"),
-        AI_INFO("ai info", false, false, false, "AI info"),
-        AI_INFO_INPUT("ai info", true, false, false, "AI info"),
+        AI_INFO("ai inspect info", false, false, false, "AI info"),
+        AI_INFO_INPUT("ai inspect info", true, false, false, "AI info"),
 
         MAIN_INFO("terminatorplus", false, false, false, "Plugin information"),
         MAIN_DEBUG_INFO("terminatorplus debuginfo", false, false, false, "Debug upload"),
 
-        ENV_HELP("botenvironment help", false, false, false, "Environment help"),
-        ENV_GET_MATERIAL("botenvironment getMaterial", true, false, false, "Get material"),
-        ENV_ADD_SOLID("botenvironment addSolid", true, false, false, "Add solid"),
-        ENV_REMOVE_SOLID("botenvironment removeSolid", true, true, false, "Remove solid"),
-        ENV_LIST_SOLIDS("botenvironment listSolids", false, false, false, "List solids"),
-        ENV_CLEAR_SOLIDS("botenvironment clearSolids", false, true, false, "Clear solids"),
-        ENV_ADD_CUSTOM_MOB("botenvironment addCustomMob", true, false, false, "Add custom mob"),
-        ENV_REMOVE_CUSTOM_MOB("botenvironment removeCustomMob", true, true, false, "Remove custom mob"),
-        ENV_LIST_CUSTOM_MOBS("botenvironment listCustomMobs", false, false, false, "List custom mobs"),
-        ENV_CLEAR_CUSTOM_MOBS("botenvironment clearCustomMobs", false, true, false, "Clear custom mobs"),
-        ENV_MOB_LIST_TYPE("botenvironment mobListType", true, false, false, "Mob list type"),
-        ENV_MOVEMENT_V2_STATUS("botenvironment movementV2Status", false, false, false, "Movement V2 status");
+        ENV_HELP("bot environment", false, false, false, "Environment help"),
+        ENV_GET_MATERIAL("bot environment inspect material", true, false, false, "Get material"),
+        ENV_ADD_SOLID("bot environment solid-block add", true, false, false, "Add solid"),
+        ENV_REMOVE_SOLID("bot environment solid-block remove", true, true, false, "Remove solid"),
+        ENV_LIST_SOLIDS("bot environment solid-block list", false, false, false, "List solids"),
+        ENV_CLEAR_SOLIDS("bot environment solid-block clear", false, true, false, "Clear solids"),
+        ENV_ADD_CUSTOM_MOB("bot environment custom-mob add", true, false, false, "Add custom mob"),
+        ENV_REMOVE_CUSTOM_MOB("bot environment custom-mob remove", true, true, false, "Remove custom mob"),
+        ENV_LIST_CUSTOM_MOBS("bot environment custom-mob list", false, false, false, "List custom mobs"),
+        ENV_CLEAR_CUSTOM_MOBS("bot environment custom-mob clear", false, true, false, "Clear custom mobs"),
+        ENV_MOB_LIST_TYPE("bot environment mob-list-mode set", true, false, false, "Mob list type"),
+        ENV_MOVEMENT_V2_STATUS("bot debug movement", false, false, true, "Movement V2 status");
 
         private final String command;
         private final boolean prompt;

--- a/TerminatorPlus-Plugin/src/main/java/net/nuggetmc/tplus/command/CommandInstance.java
+++ b/TerminatorPlus-Plugin/src/main/java/net/nuggetmc/tplus/command/CommandInstance.java
@@ -3,6 +3,7 @@ package net.nuggetmc.tplus.command;
 import net.nuggetmc.tplus.TerminatorPlus;
 import net.nuggetmc.tplus.api.utils.ChatUtils;
 import net.nuggetmc.tplus.command.annotation.Arg;
+import net.nuggetmc.tplus.command.annotation.Command;
 import net.nuggetmc.tplus.command.annotation.OptArg;
 import net.nuggetmc.tplus.command.annotation.TextArg;
 import net.nuggetmc.tplus.command.exception.ArgCountException;
@@ -292,11 +293,18 @@ public abstract class CommandInstance extends BukkitCommand {
     @SuppressWarnings("unchecked")
     public List<String> tabComplete(@Nonnull CommandSender sender, @Nonnull String label, @Nonnull String[] args) {
         if (args.length == 1) {
-            List<String> result = methods.keySet().stream().filter(c -> !c.isEmpty() && c.contains(args[0])).collect(Collectors.toList());
+            String prefix = args[0].toLowerCase(Locale.ROOT);
+            List<String> result = methods.values().stream()
+                    .filter(method -> visibleTo(sender, method))
+                    .map(CommandMethod::getName)
+                    .filter(name -> !name.isEmpty() && name.toLowerCase(Locale.ROOT).startsWith(prefix))
+                    .collect(Collectors.toList());
             if (result.isEmpty()) {
-                // Add aliases also
-                methods.forEach((s, m) -> result.addAll(m.getAliases()));
-                return result.stream().filter(c -> c.contains(args[0])).collect(Collectors.toList());
+                methods.values().stream()
+                        .filter(method -> visibleTo(sender, method))
+                        .flatMap(method -> method.getAliases().stream())
+                        .filter(alias -> alias.toLowerCase(Locale.ROOT).startsWith(prefix))
+                        .forEach(result::add);
             }
             return result;
         }
@@ -320,5 +328,12 @@ public abstract class CommandInstance extends BukkitCommand {
         }
 
         return new ArrayList<>();
+    }
+
+    private static boolean visibleTo(CommandSender sender, CommandMethod method) {
+        Command command = method.getMethod().getAnnotation(Command.class);
+        if (command == null || !command.visible()) return false;
+        String permission = method.getPermission();
+        return permission == null || permission.isEmpty() || sender.hasPermission(permission);
     }
 }

--- a/TerminatorPlus-Plugin/src/main/java/net/nuggetmc/tplus/command/commands/AICommand.java
+++ b/TerminatorPlus-Plugin/src/main/java/net/nuggetmc/tplus/command/commands/AICommand.java
@@ -61,8 +61,109 @@ public class AICommand extends CommandInstance implements AIManager {
     }
 
     @Command(
+            name = "spawn",
+            desc = "Spawn AI-controlled bots.",
+            autofill = "spawnAutofill"
+    )
+    public void spawn(CommandSender sender, List<String> args) {
+        if (args.isEmpty()) {
+            sendGroupHelp(sender, "/ai spawn", "random <amount> <name> [skin] [location]", "movement <amount> <name> [skin] [location]");
+            return;
+        }
+
+        if (args.get(0).equalsIgnoreCase("movement")) {
+            movement(sender, args.subList(1, args.size()));
+            return;
+        }
+        if (args.get(0).equalsIgnoreCase("random")) {
+            if (args.size() < 3) {
+                sender.sendMessage(ChatColor.RED + "Usage: /ai spawn random <amount> <name> [skin] [location]");
+                return;
+            }
+            int amount;
+            try {
+                amount = Integer.parseInt(args.get(1));
+            } catch (NumberFormatException e) {
+                sender.sendMessage(ChatColor.RED + "Amount must be a number.");
+                return;
+            }
+            String skin = args.size() >= 4 ? args.get(3) : null;
+            String location = args.size() >= 5 ? String.join(" ", args.subList(4, args.size())) : "";
+            random(sender, args.subList(1, args.size()), amount, args.get(2), skin, location);
+            return;
+        }
+        sendGroupHelp(sender, "/ai spawn", "random <amount> <name> [skin] [location]", "movement <amount> <name> [skin] [location]");
+    }
+
+    public List<String> spawnAutofill(CommandSender sender, String[] args) {
+        return args.length == 2 ? List.of("random", "movement") : List.of();
+    }
+
+    @Command(
+            name = "train",
+            desc = "Start or stop AI training.",
+            autofill = "trainAutofill"
+    )
+    public void train(CommandSender sender, List<String> args) {
+        if (args.isEmpty()) {
+            sendGroupHelp(sender, "/ai train", "reinforcement <population-size> <name> [skin] [mode] [round-minutes]", "stop");
+            return;
+        }
+        if (args.get(0).equalsIgnoreCase("stop")) {
+            stop(sender);
+            return;
+        }
+        if (!args.get(0).equalsIgnoreCase("reinforcement")) {
+            sendGroupHelp(sender, "/ai train", "reinforcement <population-size> <name> [skin] [mode] [round-minutes]", "stop");
+            return;
+        }
+        if (!(sender instanceof Player player)) {
+            sender.sendMessage("This is a player-only command.");
+            return;
+        }
+        if (args.size() < 3) {
+            sender.sendMessage(ChatColor.RED + "Usage: /ai train reinforcement <population-size> <name> [skin] [mode] [round-minutes]");
+            return;
+        }
+        int populationSize;
+        try {
+            populationSize = Integer.parseInt(args.get(1));
+        } catch (NumberFormatException e) {
+            sender.sendMessage(ChatColor.RED + "Population size must be a number.");
+            return;
+        }
+        String skin = args.size() >= 4 ? args.get(3) : null;
+        String mode = args.size() >= 5 ? args.get(4) : null;
+        String roundMinutes = args.size() >= 6 ? args.get(5) : null;
+        reinforcement(player, populationSize, args.get(2), skin, mode, roundMinutes);
+    }
+
+    public List<String> trainAutofill(CommandSender sender, String[] args) {
+        return args.length == 2 ? List.of("reinforcement", "stop") : List.of();
+    }
+
+    @Command(
+            name = "inspect",
+            desc = "Inspect AI state.",
+            autofill = "inspectAutofill"
+    )
+    public void inspect(CommandSender sender, List<String> args) {
+        if (args.size() == 2 && args.get(0).equalsIgnoreCase("info")) {
+            info(sender, args.get(1));
+            return;
+        }
+        sendGroupHelp(sender, "/ai inspect", "info <bot-name>");
+    }
+
+    public List<String> inspectAutofill(CommandSender sender, String[] args) {
+        if (args.length == 2) return List.of("info");
+        return args.length == 3 && args[1].equalsIgnoreCase("info") ? manager.fetchNames() : List.of();
+    }
+
+    @Command(
             name = "random",
-            desc = "Create bots with random neural networks, collecting feed data."
+            desc = "Create bots with random neural networks, collecting feed data.",
+            visible = false
     )
     public void random(CommandSender sender, List<String> args, @Arg("amount") int amount, @Arg("name") String name, @OptArg("skin") String skin, @OptArg("loc") @TextArg String loc) {
         if (sender instanceof Player && args.size() < 2) {
@@ -76,7 +177,8 @@ public class AICommand extends CommandInstance implements AIManager {
 
     @Command(
             name = "reinforcement",
-            desc = "Begin an AI training session."
+            desc = "Begin an AI training session.",
+            visible = false
     )
     public void reinforcement(Player sender, @Arg("population-size") int populationSize, @Arg("name") String name, @OptArg("skin") String skin, @OptArg("mode") String mode, @OptArg("round-minutes") String roundMinutesStr) {
         //FIXME: Sometimes, bots will become invisible, or just stop working if they're the last one alive, this has been partially fixed (invis part) see Terminator#removeBot, which removes the bot.
@@ -129,7 +231,8 @@ public class AICommand extends CommandInstance implements AIManager {
 
     @Command(
             name = "stop",
-            desc = "End a currently running AI training session."
+            desc = "End a currently running AI training session.",
+            visible = false
     )
     public void stop(CommandSender sender) {
         if (agent == null) {
@@ -178,7 +281,8 @@ public class AICommand extends CommandInstance implements AIManager {
 
     @Command(
             name = "movement",
-            desc = "Create movement-controller bot(s) from the persisted movement brain."
+            desc = "Create movement-controller bot(s) from the persisted movement brain.",
+            visible = false
     )
     public void movement(CommandSender sender, List<String> args) {
         if (args.size() < 2) {
@@ -295,7 +399,8 @@ public class AICommand extends CommandInstance implements AIManager {
     @Command(
             name = "info",
             desc = "Display neural network information about a bot.",
-            autofill = "infoAutofill"
+            autofill = "infoAutofill",
+            visible = false
     )
     public void info(CommandSender sender, @Arg("bot-name") String name) {
         sender.sendMessage("Processing request...");
@@ -723,6 +828,15 @@ public class AICommand extends CommandInstance implements AIManager {
         String normalized = MovementTrainingConfig.normalizeFamilyId(value);
         return MovementBrainBank.FALLBACK_BRAIN_NAME.equals(normalized)
                 || net.nuggetmc.tplus.api.agent.legacyagent.ai.movement.MovementNetworkShape.BRANCH_FAMILY_IDS.contains(normalized);
+    }
+
+    private void sendGroupHelp(CommandSender sender, String command, String... entries) {
+        sender.sendMessage(ChatUtils.LINE);
+        sender.sendMessage(ChatColor.GOLD + "Command help" + ChatColor.GRAY + " [" + ChatColor.YELLOW + command + ChatColor.GRAY + "]");
+        for (String entry : entries) {
+            sender.sendMessage(ChatUtils.BULLET_FORMATTED + ChatColor.YELLOW + command + " " + entry);
+        }
+        sender.sendMessage(ChatUtils.LINE);
     }
 
     private record MovementTrainingRequest(

--- a/TerminatorPlus-Plugin/src/main/java/net/nuggetmc/tplus/command/commands/BotCommand.java
+++ b/TerminatorPlus-Plugin/src/main/java/net/nuggetmc/tplus/command/commands/BotCommand.java
@@ -71,8 +71,226 @@ public class BotCommand extends CommandInstance {
     }
 
     @Command(
+            name = "spawn",
+            desc = "Spawn one or more bots.",
+            autofill = "spawnAutofill"
+    )
+    public void spawn(CommandSender sender, List<String> args) {
+        if (args.isEmpty()) {
+            sendGroupHelp(sender, "/bot spawn", "single <name> [skin] [location]", "multiple <amount> <name> [skin] [location]");
+            return;
+        }
+
+        switch (args.get(0).toLowerCase(Locale.ROOT)) {
+            case "single" -> {
+                if (args.size() < 2) {
+                    sender.sendMessage(ChatColor.RED + "Usage: /bot spawn single <name> [skin] [location]");
+                    return;
+                }
+                String skin = args.size() >= 3 ? args.get(2) : null;
+                String location = args.size() >= 4 ? String.join(" ", args.subList(3, args.size())) : null;
+                createBots(sender, args.get(1), skin, location, 1);
+            }
+            case "multiple" -> {
+                if (args.size() < 3) {
+                    sender.sendMessage(ChatColor.RED + "Usage: /bot spawn multiple <amount> <name> [skin] [location]");
+                    return;
+                }
+                int amount;
+                try {
+                    amount = Integer.parseInt(args.get(1));
+                } catch (NumberFormatException e) {
+                    sender.sendMessage(ChatColor.RED + "Amount must be a number.");
+                    return;
+                }
+                String skin = args.size() >= 4 ? args.get(3) : null;
+                String location = args.size() >= 5 ? String.join(" ", args.subList(4, args.size())) : null;
+                createBots(sender, args.get(2), skin, location, amount);
+            }
+            default -> sendGroupHelp(sender, "/bot spawn", "single <name> [skin] [location]", "multiple <amount> <name> [skin] [location]");
+        }
+    }
+
+    public List<String> spawnAutofill(CommandSender sender, String[] args) {
+        return args.length == 2 ? List.of("single", "multiple") : List.of();
+    }
+
+    @Command(
+            name = "inspect",
+            desc = "Inspect bots and their status.",
+            autofill = "inspectAutofill"
+    )
+    public void inspect(CommandSender sender, List<String> args) {
+        if (args.isEmpty()) {
+            sendGroupHelp(sender, "/bot inspect", "list", "info [bot-name]", "weapons [bot-name]");
+            return;
+        }
+
+        switch (args.get(0).toLowerCase(Locale.ROOT)) {
+            case "list" -> count(sender);
+            case "info" -> info(sender, args.size() >= 2 ? args.get(1) : null);
+            case "weapons" -> weapons(sender, args.size() >= 2 ? args.get(1) : null);
+            default -> sendGroupHelp(sender, "/bot inspect", "list", "info [bot-name]", "weapons [bot-name]");
+        }
+    }
+
+    public List<String> inspectAutofill(CommandSender sender, String[] args) {
+        if (args.length == 2) return List.of("list", "info", "weapons");
+        if (args.length == 3 && (args[1].equalsIgnoreCase("info") || args[1].equalsIgnoreCase("weapons"))) {
+            return manager.fetchNames();
+        }
+        return List.of();
+    }
+
+    @Command(
+            name = "move",
+            desc = "Move bots as a group.",
+            autofill = "moveAutofill"
+    )
+    public void move(CommandSender sender, List<String> args) {
+        if (args.isEmpty()) {
+            sendGroupHelp(sender, "/bot move", "gather", "scatter [radius]");
+            return;
+        }
+
+        switch (args.get(0).toLowerCase(Locale.ROOT)) {
+            case "gather" -> gather(sender);
+            case "scatter" -> {
+                if (args.size() > 2) {
+                    sender.sendMessage(ChatColor.RED + "Usage: /bot move scatter [radius]");
+                    return;
+                }
+                scatter(sender, args.size() == 2 ? args.get(1) : null);
+            }
+            default -> sendGroupHelp(sender, "/bot move", "gather", "scatter [radius]");
+        }
+    }
+
+    public List<String> moveAutofill(CommandSender sender, String[] args) {
+        return args.length == 2 ? List.of("gather", "scatter") : List.of();
+    }
+
+    @Command(
+            name = "equipment",
+            desc = "Manage bot equipment, inventories, and loadouts.",
+            autofill = "equipmentAutofill"
+    )
+    public void equipment(CommandSender sender, List<String> args) {
+        if (args.isEmpty()) {
+            sendGroupHelp(sender, "/bot equipment", "inventory <bot-name>", "give <item> [bot-name] [slot]",
+                    "armor <tier>", "loadout <name> [bot-name]", "mixed-loadout <mix> [bot-prefix]");
+            return;
+        }
+
+        switch (args.get(0).toLowerCase(Locale.ROOT)) {
+            case "inventory" -> {
+                if (args.size() < 2) {
+                    sender.sendMessage(ChatColor.RED + "Usage: /bot equipment inventory <bot-name>");
+                    return;
+                }
+                inventory(sender, args.get(1));
+            }
+            case "give" -> give(sender, args.subList(1, args.size()));
+            case "armor" -> {
+                if (args.size() < 2) {
+                    sender.sendMessage(ChatColor.RED + "Usage: /bot equipment armor <tier>");
+                    return;
+                }
+                armor(sender, args.get(1));
+            }
+            case "loadout" -> {
+                if (args.size() < 2) {
+                    sender.sendMessage(ChatColor.RED + "Usage: /bot equipment loadout <name> [bot-name]");
+                    return;
+                }
+                loadout(sender, args.get(1), args.size() >= 3 ? args.get(2) : null);
+            }
+            case "mixed-loadout", "loadoutmix" -> {
+                if (args.size() < 2) {
+                    sender.sendMessage(ChatColor.RED + "Usage: /bot equipment mixed-loadout <mix> [bot-prefix]");
+                    return;
+                }
+                loadoutMix(sender, args.get(1), args.size() >= 3 ? args.get(2) : null);
+            }
+            default -> sendGroupHelp(sender, "/bot equipment", "inventory <bot-name>", "give <item> [bot-name] [slot]",
+                    "armor <tier>", "loadout <name> [bot-name]", "mixed-loadout <mix> [bot-prefix]");
+        }
+    }
+
+    public List<String> equipmentAutofill(CommandSender sender, String[] args) {
+        if (args.length == 2) return List.of("inventory", "give", "armor", "loadout", "mixed-loadout");
+        if (args.length == 3) {
+            return switch (args[1].toLowerCase(Locale.ROOT)) {
+                case "inventory" -> manager.fetchNames();
+                case "give" -> giveAutofill(sender, new String[]{"give", args[2]});
+                case "armor" -> new ArrayList<>(armorTiers.keySet());
+                case "loadout" -> Arrays.asList(LOADOUT_NAMES);
+                case "mixed-loadout" -> Arrays.asList(LOADOUT_MIX_NAMES);
+                default -> List.of();
+            };
+        }
+        if (args.length == 4 && args[1].equalsIgnoreCase("give")) {
+            return manager.fetchNames();
+        }
+        if (args.length == 5 && args[1].equalsIgnoreCase("give")) {
+            return giveAutofill(sender, new String[]{"give", args[2], args[3], args[4]});
+        }
+        if (args.length == 4 && args[1].equalsIgnoreCase("loadout")) return manager.fetchNames();
+        if (args.length == 4 && args[1].equalsIgnoreCase("mixed-loadout")) return manager.fetchNames();
+        return List.of();
+    }
+
+    @Command(
+            name = "admin",
+            desc = "Administrative bot actions.",
+            autofill = "adminAutofill"
+    )
+    @Require(ADMIN_PERMISSION)
+    public void admin(CommandSender sender, List<String> args) {
+        if (args.size() == 1 && args.get(0).equalsIgnoreCase("reset")) {
+            reset(sender);
+            return;
+        }
+        sendGroupHelp(sender, "/bot admin", "reset");
+    }
+
+    public List<String> adminAutofill(CommandSender sender, String[] args) {
+        return args.length == 2 ? List.of("reset") : List.of();
+    }
+
+    @Command(
+            name = "environment",
+            desc = "Inspect and configure bot environment data.",
+            autofill = "environmentAutofill"
+    )
+    public void environment(CommandSender sender, List<String> args) {
+        BotEnvironmentCommand environment = environmentCommand();
+        if (environment == null) {
+            sender.sendMessage(ChatColor.RED + "Environment commands are unavailable.");
+            return;
+        }
+        environment.dispatchCanonical(sender, args);
+    }
+
+    public List<String> environmentAutofill(CommandSender sender, String[] args) {
+        if (args.length == 2) return List.of("inspect", "material", "solid-block", "custom-mob", "mob-list-mode");
+        if (args.length == 3 && (args[1].equalsIgnoreCase("inspect") || args[1].equalsIgnoreCase("material"))) {
+            return List.of("material");
+        }
+        if (args.length == 3 && args[1].equalsIgnoreCase("solid-block")) return List.of("add", "remove", "list", "clear");
+        if (args.length == 3 && args[1].equalsIgnoreCase("custom-mob")) return List.of("add", "remove", "list", "clear");
+        if (args.length == 3 && args[1].equalsIgnoreCase("mob-list-mode")) return List.of("get", "set");
+        if (args.length == 4 && args[1].equalsIgnoreCase("mob-list-mode") && args[2].equalsIgnoreCase("set")) {
+            return Arrays.stream(net.nuggetmc.tplus.api.agent.legacyagent.CustomListMode.values())
+                    .map(mode -> mode.name().toLowerCase(Locale.ROOT)).toList();
+        }
+        return List.of();
+    }
+
+    @Command(
             name = "create",
-            desc = "Create a bot."
+            desc = "Create a bot.",
+            visible = false
     )
     public void create(CommandSender sender, @Arg("name") String name, @OptArg("skin") String skin, @TextArg @OptArg("loc") String loc) {
         createBots(sender, name, skin, loc, 1);
@@ -80,7 +298,8 @@ public class BotCommand extends CommandInstance {
 
     @Command(
             name = "multi",
-            desc = "Create multiple bots at once."
+            desc = "Create multiple bots at once.",
+            visible = false
     )
     public void multi(CommandSender sender, @Arg("amount") int amount, @Arg("name") String name, @OptArg("skin") String skin, @TextArg @OptArg("loc") String loc) {
         createBots(sender, name, skin, loc, amount);
@@ -89,7 +308,8 @@ public class BotCommand extends CommandInstance {
     @Command(
             name = "respawn",
             desc = "Enable, disable, or show automatic bot respawning.",
-            autofill = "respawnAutofill"
+            autofill = "respawnAutofill",
+            visible = false
     )
     @Require(ADMIN_PERMISSION)
     public void respawn(CommandSender sender, @OptArg("enabled") String value) {
@@ -125,7 +345,8 @@ public class BotCommand extends CommandInstance {
     @Command(
             name = "movementv2",
             desc = "Enable, disable, or show Movement V2.",
-            autofill = "movementV2Autofill"
+            autofill = "movementV2Autofill",
+            visible = false
     )
     @Require(ADMIN_PERMISSION)
     public void movementV2(CommandSender sender, @OptArg("on-off-status") String action) {
@@ -170,7 +391,8 @@ public class BotCommand extends CommandInstance {
     @Command(
             name = "give",
             desc = "Give an item to bot(s). Usage: /bot give <item> [bot-name] [slot]",
-            autofill = "giveAutofill"
+            autofill = "giveAutofill",
+            visible = false
     )
     public void give(CommandSender sender, List<String> args) {
         if (args.isEmpty()) {
@@ -249,7 +471,8 @@ public class BotCommand extends CommandInstance {
     @Command(
             name = "place",
             desc = "Set the block bots use when placing blocks.",
-            autofill = "placeAutofill"
+            autofill = "placeAutofill",
+            visible = false
     )
     public void place(CommandSender sender, @Arg("material") String materialName) {
         Material material = materialName == null ? null : Material.matchMaterial(materialName);
@@ -335,7 +558,8 @@ public class BotCommand extends CommandInstance {
     @Command(
             name = "armor",
             desc = "Gives all bots an armor set.",
-            autofill = "armorAutofill"
+            autofill = "armorAutofill",
+            visible = false
     )
     public void armor(CommandSender sender, @Arg("armor-tier") String armorTier) {
         String tier = armorTier.toLowerCase();
@@ -371,7 +595,8 @@ public class BotCommand extends CommandInstance {
     @Command(
             name = "info",
             desc = "Information about loaded bots.",
-            autofill = "infoAutofill"
+            autofill = "infoAutofill",
+            visible = false
     )
     public void info(CommandSender sender, @OptArg("bot-name") String name) {
         if (name == null) {
@@ -415,7 +640,8 @@ public class BotCommand extends CommandInstance {
             desc = "Counts the amount of bots on screen by name.",
             aliases = {
                     "list"
-            }
+            },
+            visible = false
     )
     public void count(CommandSender sender) {
         List<String> names = manager.fetchNames();
@@ -432,7 +658,8 @@ public class BotCommand extends CommandInstance {
 
     @Command(
             name = "reset",
-            desc = "Remove all loaded bots."
+            desc = "Remove all loaded bots.",
+            visible = false
     )
     @Require(ADMIN_PERMISSION)
     public void reset(CommandSender sender) {
@@ -457,23 +684,28 @@ public class BotCommand extends CommandInstance {
             autofill = "settingsAutofill"
     )
     public void settings(CommandSender sender, List<String> args) {
-        String arg1 = args.isEmpty() ? null : args.get(0);
+        String arg1 = args.isEmpty() ? null : canonicalSettingsAction(args.get(0));
         String arg2 = args.size() < 2 ? null : args.get(1);
 
         String extra = ChatColor.GRAY + " [" + ChatColor.YELLOW + "/bot settings" + ChatColor.GRAY + "]";
 
-        if (arg1 == null || (!arg1.equalsIgnoreCase("setgoal") && !arg1.equalsIgnoreCase("mobtarget") && !arg1.equalsIgnoreCase("playertarget")
-                && !arg1.equalsIgnoreCase("addplayerlist") && !arg1.equalsIgnoreCase("region"))) {
+        if (arg1 == null || (!arg1.equalsIgnoreCase("combat-goal") && !arg1.equalsIgnoreCase("target-mobs") && !arg1.equalsIgnoreCase("target-player")
+                && !arg1.equalsIgnoreCase("show-in-player-list") && !arg1.equalsIgnoreCase("target-region")
+                && !arg1.equalsIgnoreCase("auto-respawn") && !arg1.equalsIgnoreCase("movement-v2")
+                && !arg1.equalsIgnoreCase("placement-material"))) {
             sender.sendMessage(ChatUtils.LINE);
             sender.sendMessage(ChatColor.GOLD + "Bot Settings" + extra);
-            sender.sendMessage(ChatUtils.BULLET_FORMATTED + ChatColor.YELLOW + "setgoal" + ChatUtils.BULLET_FORMATTED + "Set the global bot target selection method.");
-            sender.sendMessage(ChatUtils.BULLET_FORMATTED + ChatColor.YELLOW + "mobtarget" + ChatUtils.BULLET_FORMATTED + "Allow all bots to be targeted by hostile mobs.");
-            sender.sendMessage(ChatUtils.BULLET_FORMATTED + ChatColor.YELLOW + "playertarget" + ChatUtils.BULLET_FORMATTED + "Sets a player name for spawned bots to focus on if the goal is PLAYER.");
-            sender.sendMessage(ChatUtils.BULLET_FORMATTED + ChatColor.YELLOW + "addplayerlist" + ChatUtils.BULLET_FORMATTED + "Adds newly spawned bots to the player list. This allows the bots to be affected by player selectors like @a and @p.");
-            sender.sendMessage(ChatUtils.BULLET_FORMATTED + ChatColor.YELLOW + "region" + ChatUtils.BULLET_FORMATTED + "Sets a region for the bots to prioritize entities inside.");
+            sender.sendMessage(ChatUtils.BULLET_FORMATTED + ChatColor.YELLOW + "combat-goal" + ChatUtils.BULLET_FORMATTED + "Set the global bot target selection method.");
+            sender.sendMessage(ChatUtils.BULLET_FORMATTED + ChatColor.YELLOW + "target-mobs" + ChatUtils.BULLET_FORMATTED + "Allow all bots to be targeted by hostile mobs.");
+            sender.sendMessage(ChatUtils.BULLET_FORMATTED + ChatColor.YELLOW + "target-player" + ChatUtils.BULLET_FORMATTED + "Set a player name for spawned bots to focus on if the goal is PLAYER.");
+            sender.sendMessage(ChatUtils.BULLET_FORMATTED + ChatColor.YELLOW + "target-region" + ChatUtils.BULLET_FORMATTED + "Set a region for the bots to prioritize entities inside.");
+            sender.sendMessage(ChatUtils.BULLET_FORMATTED + ChatColor.YELLOW + "show-in-player-list" + ChatUtils.BULLET_FORMATTED + "Add newly spawned bots to the player list.");
+            sender.sendMessage(ChatUtils.BULLET_FORMATTED + ChatColor.YELLOW + "auto-respawn" + ChatUtils.BULLET_FORMATTED + "Enable or disable automatic bot respawning.");
+            sender.sendMessage(ChatUtils.BULLET_FORMATTED + ChatColor.YELLOW + "movement-v2" + ChatUtils.BULLET_FORMATTED + "Enable, disable, or inspect Movement V2.");
+            sender.sendMessage(ChatUtils.BULLET_FORMATTED + ChatColor.YELLOW + "placement-material" + ChatUtils.BULLET_FORMATTED + "Set the block bots use when placing blocks.");
             sender.sendMessage(ChatUtils.LINE);
             return;
-        } else if (arg1.equalsIgnoreCase("setgoal")) {
+        } else if (arg1.equalsIgnoreCase("combat-goal")) {
             if (arg2 == null) {
                 sender.sendMessage("The global bot goal is currently " + ChatColor.BLUE + agent.getTargetType() + ChatColor.RESET + ".");
                 return;
@@ -490,7 +722,7 @@ public class BotCommand extends CommandInstance {
             }
             agent.setTargetType(goal);
             sender.sendMessage("The global bot goal has been set to " + ChatColor.BLUE + goal.name() + ChatColor.RESET + ".");
-        } else if (arg1.equalsIgnoreCase("mobtarget")) {
+        } else if (arg1.equalsIgnoreCase("target-mobs")) {
             if (arg2 == null) {
                 sender.sendMessage("Mob targeting is currently " + (manager.isMobTarget() ? ChatColor.GREEN + "enabled" : ChatColor.RED + "disabled") + ChatColor.RESET + ".");
                 return;
@@ -502,7 +734,7 @@ public class BotCommand extends CommandInstance {
             }
             manager.setMobTarget(enabled);
             sender.sendMessage("Mob targeting is now " + (manager.isMobTarget() ? ChatColor.GREEN + "enabled" : ChatColor.RED + "disabled") + ChatColor.RESET + ".");
-        } else if (arg1.equalsIgnoreCase("playertarget")) {
+        } else if (arg1.equalsIgnoreCase("target-player")) {
             if (args.size() < 2) {
                 sender.sendMessage(ChatColor.RED + "You must specify a player name!");
                 return;
@@ -517,7 +749,7 @@ public class BotCommand extends CommandInstance {
                 fetch.setTargetPlayer(player.getUniqueId());
             }
             sender.sendMessage("All spawned bots are now set to target " + ChatColor.BLUE + player.getName() + ChatColor.RESET + ". They will target the closest player if they can't be found.\nYou may need to set the goal to PLAYER.");
-        } else if (arg1.equalsIgnoreCase("addplayerlist")) {
+        } else if (arg1.equalsIgnoreCase("show-in-player-list")) {
             if (arg2 == null) {
                 sender.sendMessage("Adding bots to the player list is currently " + (manager.addToPlayerList() ? ChatColor.GREEN + "enabled" : ChatColor.RED + "disabled") + ChatColor.RESET + ".");
                 return;
@@ -529,7 +761,7 @@ public class BotCommand extends CommandInstance {
             }
             manager.setAddToPlayerList(enabled);
             sender.sendMessage("Adding bots to the player list is now " + (manager.addToPlayerList() ? ChatColor.GREEN + "enabled" : ChatColor.RED + "disabled") + ChatColor.RESET + ".");
-        } else if (arg1.equalsIgnoreCase("region")) {
+        } else if (arg1.equalsIgnoreCase("target-region")) {
             if (arg2 == null) {
                 if (agent.getRegion() == null) {
                     sender.sendMessage("No region has been set.");
@@ -587,7 +819,7 @@ public class BotCommand extends CommandInstance {
                 }
             } catch (NumberFormatException e) {
                 sender.sendMessage("The region bounds and weights must be valid numbers!");
-                sender.sendMessage("Correct syntax: " + ChatColor.YELLOW + "/bot settings region <x1> <y1> <z1> <x2> <y2> <z2> <wX> <wY> <wZ>"
+                sender.sendMessage("Correct syntax: " + ChatColor.YELLOW + "/bot settings target-region <x1> <y1> <z1> <x2> <y2> <z2> <wX> <wY> <wZ>"
                         + ChatColor.RESET);
                 return;
             }
@@ -600,6 +832,27 @@ public class BotCommand extends CommandInstance {
                 sender.sendMessage("The region Y weight is " + ChatColor.BLUE + agent.getRegionWeightY() + ChatColor.RESET + ".");
                 sender.sendMessage("The region Z weight is " + ChatColor.BLUE + agent.getRegionWeightZ() + ChatColor.RESET + ".");
             }
+        } else if (arg1.equalsIgnoreCase("auto-respawn")) {
+            if (!requireAdmin(sender)) return;
+            if (arg2 == null || arg2.equalsIgnoreCase("status")) {
+                respawn(sender, null);
+                return;
+            }
+            Boolean enabled = parseToggleValue(arg2);
+            if (enabled == null) {
+                sender.sendMessage(ChatColor.RED + "Usage: /bot settings auto-respawn <true|false|on|off>");
+                return;
+            }
+            respawn(sender, Boolean.toString(enabled));
+        } else if (arg1.equalsIgnoreCase("movement-v2")) {
+            if (!requireAdmin(sender)) return;
+            movementV2(sender, arg2);
+        } else if (arg1.equalsIgnoreCase("placement-material")) {
+            if (arg2 == null) {
+                sender.sendMessage(ChatColor.RED + "Usage: /bot settings placement-material <material>");
+                return;
+            }
+            place(sender, arg2);
         }
     }
 
@@ -607,28 +860,30 @@ public class BotCommand extends CommandInstance {
         List<String> output = new ArrayList<>();
 
         if (args.length == 2) {
-            output.add("setgoal");
-            output.add("mobtarget");
-            output.add("playertarget");
-            output.add("addplayerlist");
-            output.add("region");
+            output.add("combat-goal");
+            output.add("target-mobs");
+            output.add("target-player");
+            output.add("target-region");
+            output.add("show-in-player-list");
+            output.add("auto-respawn");
+            output.add("movement-v2");
+            output.add("placement-material");
         } else if (args.length == 3) {
-            if (args[1].equalsIgnoreCase("setgoal")) {
+            String action = canonicalSettingsAction(args[1]);
+            if ("combat-goal".equals(action)) {
                 Arrays.stream(EnumTargetGoal.values()).forEach(goal -> output.add(goal.name().replace("_", "").toLowerCase()));
             }
-            if (args[1].equalsIgnoreCase("mobtarget")) {
+            if ("target-mobs".equals(action) || "show-in-player-list".equals(action) || "auto-respawn".equals(action)) {
                 output.add("true");
                 output.add("false");
             }
-            if (args[1].equalsIgnoreCase("playertarget")) {
+            if ("target-player".equals(action)) {
                 for (Player player : Bukkit.getOnlinePlayers()) {
                     output.add(player.getName());
                 }
             }
-            if (args[1].equalsIgnoreCase("addplayerlist")) {
-                output.add("true");
-                output.add("false");
-            }
+            if ("movement-v2".equals(action)) output.addAll(List.of("on", "off", "status"));
+            if ("placement-material".equals(action)) output.addAll(placeAutofill(sender, new String[]{"place", args[2]}));
         }
 
         return output;
@@ -636,23 +891,70 @@ public class BotCommand extends CommandInstance {
 
     @Command(
             name = "debug",
-            desc = "Debug plugin code.",
-            visible = false,
+            desc = "Inspect bot behavior and debug output.",
             autofill = "debugAutofill"
     )
     @Require(ADMIN_PERMISSION)
-    public void debug(CommandSender sender, @Arg("expression") String expression) {
-        new Debugger(sender).execute(expression);
+    public void debug(CommandSender sender, List<String> args) {
+        if (args.isEmpty()) {
+            sendGroupHelp(sender, "/bot debug", "behavior <expression>", "combat <bot-name|all> <on|off>", "movement [bot-name]");
+            return;
+        }
+
+        String action = args.get(0).toLowerCase(Locale.ROOT);
+        if (action.equals("behavior") || action.equals("expression")) {
+            if (args.size() < 2) {
+                sender.sendMessage(ChatColor.RED + "Usage: /bot debug behavior <expression>");
+                return;
+            }
+            new Debugger(sender).execute(String.join(" ", args.subList(1, args.size())));
+        } else if (action.equals("combat")) {
+            if (args.size() != 3) {
+                sender.sendMessage(ChatColor.RED + "Usage: /bot debug combat <bot-name|all> <on|off>");
+                return;
+            }
+            combatDebug(sender, args.get(1), args.get(2));
+        } else if (action.equals("movement")) {
+            if (args.size() > 2) {
+                sender.sendMessage(ChatColor.RED + "Usage: /bot debug movement [bot-name]");
+                return;
+            }
+            BotEnvironmentCommand environment = environmentCommand();
+            if (environment == null) {
+                sender.sendMessage(ChatColor.RED + "Movement debug is unavailable.");
+                return;
+            }
+            environment.movementV2Status(sender, args.size() == 2 ? List.of(args.get(1)) : List.of());
+        } else {
+            // Keep the old /bot debug <expression> form working.
+            new Debugger(sender).execute(String.join(" ", args));
+        }
     }
 
     public List<String> debugAutofill(CommandSender sender, String[] args) {
-        return args.length == 2 ? new ArrayList<>(Debugger.AUTOFILL_METHODS) : new ArrayList<>();
+        if (args.length == 2) {
+            List<String> output = new ArrayList<>(List.of("behavior", "combat", "movement", "expression"));
+            output.addAll(Debugger.AUTOFILL_METHODS);
+            return output;
+        }
+        if (args.length == 3 && args[1].equalsIgnoreCase("combat")) {
+            List<String> output = new ArrayList<>(manager.fetchNames());
+            output.add("all");
+            return output;
+        }
+        if (args.length == 4 && args[1].equalsIgnoreCase("combat")) return List.of("on", "off");
+        if (args.length == 3 && (args[1].equalsIgnoreCase("behavior") || args[1].equalsIgnoreCase("expression"))) {
+            return new ArrayList<>(Debugger.AUTOFILL_METHODS);
+        }
+        if (args.length == 3 && args[1].equalsIgnoreCase("movement")) return manager.fetchNames();
+        return List.of();
     }
 
     @Command(
             name = "weapons",
             desc = "Show which combat behaviors each bot's inventory unlocks.",
-            autofill = "weaponsAutofill"
+            autofill = "weaponsAutofill",
+            visible = false
     )
     public void weapons(CommandSender sender, @OptArg("bot-name") String botName) {
         Location viewer = sender instanceof Player p ? p.getLocation() : null;
@@ -709,7 +1011,8 @@ public class BotCommand extends CommandInstance {
             name = "combatdebug",
             desc = "Toggle full combat + movement trace logging for one bot or all bots.",
             aliases = {"cdbg", "comatdebug"},
-            autofill = "combatDebugAutofill"
+            autofill = "combatDebugAutofill",
+            visible = false
     )
     @Require(ADMIN_PERMISSION)
     public void combatDebug(CommandSender sender, @Arg("name-or-all") String target, @Arg("on-off") String state) {
@@ -776,7 +1079,8 @@ public class BotCommand extends CommandInstance {
     @Command(
             name = "gather",
             desc = "Teleport every living bot to your current location.",
-            aliases = {"tpall"}
+            aliases = {"tpall"},
+            visible = false
     )
     public void gather(CommandSender sender) {
         if (!(sender instanceof Player player)) {
@@ -796,7 +1100,8 @@ public class BotCommand extends CommandInstance {
 
     @Command(
             name = "scatter",
-            desc = "Distribute every living bot around your current location within an optional radius."
+            desc = "Distribute every living bot around your current location within an optional radius.",
+            visible = false
     )
     public void scatter(CommandSender sender, @OptArg("radius") String radiusText) {
         if (!(sender instanceof Player player)) {
@@ -1065,7 +1370,8 @@ public class BotCommand extends CommandInstance {
             name = "inventory",
             desc = "Opens the inventory editor GUI for a bot.",
             aliases = {"inv"},
-            autofill = "inventoryAutofill"
+            autofill = "inventoryAutofill",
+            visible = false
     )
     public void inventory(CommandSender sender, @Arg("bot-name") String name) {
         if (!(sender instanceof Player player)) {
@@ -1188,7 +1494,6 @@ public class BotCommand extends CommandInstance {
         List<String> out = new ArrayList<>();
         if (args.length == 2) {
             out.add("save");
-            out.add("load");
             out.add("apply");
             out.add("list");
             out.add("delete");
@@ -1211,7 +1516,8 @@ public class BotCommand extends CommandInstance {
     @Command(
             name = "loadout",
             desc = "Apply a predefined combat loadout. Usage: /bot loadout <name> [bot-name]",
-            autofill = "loadoutAutofill"
+            autofill = "loadoutAutofill",
+            visible = false
     )
     public void loadout(CommandSender sender, @Arg("name") String name, @OptArg("bot-name") String botName) {
         String key = name == null ? "" : name.toLowerCase();
@@ -1296,7 +1602,8 @@ public class BotCommand extends CommandInstance {
     @Command(
             name = "loadoutmix",
             desc = "Apply rotating combat loadouts. Usage: /bot loadoutmix <alltypes|core|problem> [bot-prefix]",
-            autofill = "loadoutMixAutofill"
+            autofill = "loadoutMixAutofill",
+            visible = false
     )
     public void loadoutMix(CommandSender sender, @Arg("mix") String mix, @OptArg("bot-prefix") String botPrefix) {
         String key = mix == null ? "" : mix.toLowerCase();
@@ -1729,6 +2036,48 @@ public class BotCommand extends CommandInstance {
         Terminator t = manager.getFirst(name, near);
         if (t instanceof Bot b) return b;
         return null;
+    }
+
+    static String canonicalSettingsAction(String action) {
+        if (action == null) return null;
+        return switch (action.toLowerCase(Locale.ROOT)) {
+            case "setgoal", "combat-goal", "target-goal" -> "combat-goal";
+            case "mobtarget", "target-mobs" -> "target-mobs";
+            case "playertarget", "target-player" -> "target-player";
+            case "region", "target-region" -> "target-region";
+            case "addplayerlist", "show-in-player-list" -> "show-in-player-list";
+            case "respawn", "auto-respawn" -> "auto-respawn";
+            case "movementv2", "movement-v2" -> "movement-v2";
+            case "place", "placement-material" -> "placement-material";
+            default -> null;
+        };
+    }
+
+    private Boolean parseToggleValue(String value) {
+        if ("on".equalsIgnoreCase(value)) return true;
+        if ("off".equalsIgnoreCase(value)) return false;
+        return parseBoolean(value);
+    }
+
+    private boolean requireAdmin(CommandSender sender) {
+        if (sender.hasPermission(ADMIN_PERMISSION)) return true;
+        sender.sendMessage(ChatColor.RED + "You do not have permission to use this subcommand.");
+        sender.sendMessage(ChatColor.RED + "Required: " + ChatColor.YELLOW + ADMIN_PERMISSION);
+        return false;
+    }
+
+    private void sendGroupHelp(CommandSender sender, String command, String... entries) {
+        sender.sendMessage(ChatUtils.LINE);
+        sender.sendMessage(ChatColor.GOLD + "Command help" + ChatColor.GRAY + " [" + ChatColor.YELLOW + command + ChatColor.GRAY + "]");
+        for (String entry : entries) {
+            sender.sendMessage(ChatUtils.BULLET_FORMATTED + ChatColor.YELLOW + command + " " + entry);
+        }
+        sender.sendMessage(ChatUtils.LINE);
+    }
+
+    private BotEnvironmentCommand environmentCommand() {
+        CommandInstance command = commandHandler.getCommand("botenvironment");
+        return command instanceof BotEnvironmentCommand environment ? environment : null;
     }
 
     private Boolean parseBooleanValue(String value) {

--- a/TerminatorPlus-Plugin/src/main/java/net/nuggetmc/tplus/command/commands/BotEnvironmentCommand.java
+++ b/TerminatorPlus-Plugin/src/main/java/net/nuggetmc/tplus/command/commands/BotEnvironmentCommand.java
@@ -35,6 +35,105 @@ public class BotEnvironmentCommand extends CommandInstance {
         commandHandler.sendRootInfo(this, sender);
     }
 
+    void dispatchCanonical(CommandSender sender, List<String> args) {
+        if (args.isEmpty()) {
+            sendCanonicalHelp(sender);
+            return;
+        }
+
+        String group = args.get(0).toLowerCase(Locale.ROOT);
+        switch (group) {
+            case "help" -> help(sender, args.subList(1, args.size()));
+            case "blocks", "mobs" -> help(sender, args);
+            case "inspect", "material" -> dispatchMaterial(sender, args);
+            case "solid-block" -> dispatchSolidBlock(sender, args);
+            case "custom-mob" -> dispatchCustomMob(sender, args);
+            case "mob-list-mode" -> dispatchMobListMode(sender, args);
+            default -> sendCanonicalHelp(sender);
+        }
+    }
+
+    private void dispatchMaterial(CommandSender sender, List<String> args) {
+        int coordinateStart = 1;
+        if (args.get(0).equalsIgnoreCase("inspect") && args.size() > 1 && args.get(1).equalsIgnoreCase("material")) {
+            coordinateStart = 2;
+        } else if (args.get(0).equalsIgnoreCase("material") && args.size() > 1 && args.get(1).equalsIgnoreCase("inspect")) {
+            coordinateStart = 2;
+        }
+        if (args.size() - coordinateStart != 3) {
+            sender.sendMessage(ChatColor.RED + "Usage: /bot environment inspect material <x> <y> <z>");
+            return;
+        }
+        if (!(sender instanceof Player player)) {
+            sender.sendMessage("This is a player-only command.");
+            return;
+        }
+        getMaterial(player, args.get(coordinateStart), args.get(coordinateStart + 1), args.get(coordinateStart + 2));
+    }
+
+    private void dispatchSolidBlock(CommandSender sender, List<String> args) {
+        if (args.size() < 2) {
+            sendCanonicalHelp(sender);
+            return;
+        }
+        List<String> values = args.subList(2, args.size());
+        switch (args.get(1).toLowerCase(Locale.ROOT)) {
+            case "add" -> addSolid(sender, values);
+            case "remove" -> removeSolid(sender, values);
+            case "list" -> listSolids(sender);
+            case "clear" -> clearSolids(sender);
+            default -> sendCanonicalHelp(sender);
+        }
+    }
+
+    private void dispatchCustomMob(CommandSender sender, List<String> args) {
+        if (args.size() < 2) {
+            sendCanonicalHelp(sender);
+            return;
+        }
+        switch (args.get(1).toLowerCase(Locale.ROOT)) {
+            case "add" -> {
+                if (args.size() != 3) {
+                    sender.sendMessage(ChatColor.RED + "Usage: /bot environment custom-mob add <entity-type>");
+                    return;
+                }
+                addCustomMob(sender, args.get(2));
+            }
+            case "remove" -> {
+                if (args.size() != 3) {
+                    sender.sendMessage(ChatColor.RED + "Usage: /bot environment custom-mob remove <entity-type>");
+                    return;
+                }
+                removeCustomMob(sender, args.get(2));
+            }
+            case "list" -> listCustomMobs(sender);
+            case "clear" -> clearCustomMobs(sender);
+            default -> sendCanonicalHelp(sender);
+        }
+    }
+
+    private void dispatchMobListMode(CommandSender sender, List<String> args) {
+        if (args.size() == 1 || args.get(1).equalsIgnoreCase("get")) {
+            mobListType(sender, List.of());
+            return;
+        }
+        if (args.get(1).equalsIgnoreCase("set") && args.size() == 3) {
+            mobListType(sender, List.of(args.get(2)));
+            return;
+        }
+        sender.sendMessage(ChatColor.RED + "Usage: /bot environment mob-list-mode <get|set> [mode]");
+    }
+
+    private void sendCanonicalHelp(CommandSender sender) {
+        sender.sendMessage(ChatUtils.LINE);
+        sender.sendMessage(ChatColor.GOLD + "Environment commands");
+        sender.sendMessage(ChatUtils.BULLET_FORMATTED + ChatColor.YELLOW + "/bot environment inspect material <x> <y> <z>");
+        sender.sendMessage(ChatUtils.BULLET_FORMATTED + ChatColor.YELLOW + "/bot environment solid-block <add|remove|list|clear>");
+        sender.sendMessage(ChatUtils.BULLET_FORMATTED + ChatColor.YELLOW + "/bot environment custom-mob <add|remove|list|clear>");
+        sender.sendMessage(ChatUtils.BULLET_FORMATTED + ChatColor.YELLOW + "/bot environment mob-list-mode <get|set> [mode]");
+        sender.sendMessage(ChatUtils.LINE);
+    }
+
     @Command(
             name = "help",
             desc = "Help for /botenvironment.",

--- a/TerminatorPlus-Plugin/src/test/java/net/nuggetmc/tplus/bot/gui/BotManagementUITest.java
+++ b/TerminatorPlus-Plugin/src/test/java/net/nuggetmc/tplus/bot/gui/BotManagementUITest.java
@@ -36,11 +36,11 @@ class BotManagementUITest {
 
     @Test
     void commandMappingUsesExistingPlayerCommands() {
-        assertEquals("bot create", BotManagementUI.commandFor(BotManagementUI.UiAction.BOT_CREATE));
-        assertEquals("bot multi 3 bot", BotManagementUI.commandFor(
+        assertEquals("bot spawn single", BotManagementUI.commandFor(BotManagementUI.UiAction.BOT_CREATE));
+        assertEquals("bot spawn multiple 3 bot", BotManagementUI.commandFor(
                 BotManagementUI.UiAction.BOT_MULTI, "3 bot"));
         assertEquals("ai brain reset", BotManagementUI.commandFor(BotManagementUI.UiAction.AI_BRAIN_RESET));
-        assertEquals("botenvironment movementV2Status", BotManagementUI.commandFor(
+        assertEquals("bot debug movement", BotManagementUI.commandFor(
                 BotManagementUI.UiAction.ENV_MOVEMENT_V2_STATUS));
         assertEquals("terminatorplus debuginfo", BotManagementUI.commandFor(
                 BotManagementUI.UiAction.MAIN_DEBUG_INFO));
@@ -99,7 +99,7 @@ class BotManagementUITest {
     void duplicateNamesCannotUseSelectedBotActions() {
         assertTrue(BotManagementUI.isUniqueBotName("bot", List.of("bot", "other")));
         assertFalse(BotManagementUI.isUniqueBotName("bot", List.of("bot", "BOT")));
-        assertEquals("bot settings region 0 0 0 10 10 10", BotManagementUI.commandFor(
+        assertEquals("bot settings target-region 0 0 0 10 10 10", BotManagementUI.commandFor(
                 BotManagementUI.UiAction.BOT_SETTINGS_REGION_INPUT, "0 0 0 10 10 10"));
     }
 

--- a/TerminatorPlus-Plugin/src/test/java/net/nuggetmc/tplus/command/commands/CommandOrganizationTest.java
+++ b/TerminatorPlus-Plugin/src/test/java/net/nuggetmc/tplus/command/commands/CommandOrganizationTest.java
@@ -1,0 +1,56 @@
+package net.nuggetmc.tplus.command.commands;
+
+import net.nuggetmc.tplus.command.annotation.Command;
+import net.nuggetmc.tplus.api.agent.legacyagent.EnumTargetGoal;
+import org.bukkit.command.CommandSender;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Method;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class CommandOrganizationTest {
+
+    @Test
+    void botCanonicalGroupsAreVisibleAndLegacyLeavesStayHidden() throws Exception {
+        for (String method : List.of("spawn", "inspect", "move", "equipment", "settings", "preset", "debug", "admin", "environment")) {
+            assertTrue(command(BotCommand.class, method).visible(), method);
+        }
+        for (String method : List.of("create", "multi", "give", "place", "armor", "info", "count", "reset", "weapons", "combatDebug", "gather", "scatter", "inventory", "loadout", "loadoutMix")) {
+            assertFalse(command(BotCommand.class, method).visible(), method);
+        }
+    }
+
+    @Test
+    void canonicalSettingsKeepLegacyAliasesAndNormalizeGoalNames() {
+        assertEquals("combat-goal", BotCommand.canonicalSettingsAction("setgoal"));
+        assertEquals("target-mobs", BotCommand.canonicalSettingsAction("mobtarget"));
+        assertEquals("target-region", BotCommand.canonicalSettingsAction("TARGET-REGION"));
+        assertEquals("movement-v2", BotCommand.canonicalSettingsAction("movementv2"));
+        assertEquals("placement-material", BotCommand.canonicalSettingsAction("place"));
+        assertEquals(null, BotCommand.canonicalSettingsAction("unknown"));
+        assertEquals(EnumTargetGoal.NEAREST_HOSTILE, EnumTargetGoal.from("NEAREST-HOSTILE"));
+    }
+
+    @Test
+    void aiCanonicalGroupsAreVisibleAndLegacyLeavesStayHidden() throws Exception {
+        for (String method : List.of("spawn", "train", "brain", "evaluate", "inspect")) {
+            assertTrue(command(AICommand.class, method).visible(), method);
+        }
+        for (String method : List.of("random", "reinforcement", "stop", "movement", "info")) {
+            assertFalse(command(AICommand.class, method).visible(), method);
+        }
+    }
+
+    private static Command command(Class<?> type, String methodName) throws Exception {
+        for (Method method : type.getDeclaredMethods()) {
+            if (method.getName().equals(methodName) && method.isAnnotationPresent(Command.class)) {
+                return method.getAnnotation(Command.class);
+            }
+        }
+        throw new NoSuchMethodException(methodName);
+    }
+}

--- a/buildSrc/src/main/kotlin/net.nuggetmc.java-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/net.nuggetmc.java-conventions.gradle.kts
@@ -3,4 +3,4 @@ plugins {
 }
 
 group = "net.nuggetmc"
-version = "6.2.1-BETA-mc26.2"
+version = "6.2.2-BETA-mc26.2"

--- a/wiki/Commands.md
+++ b/wiki/Commands.md
@@ -6,39 +6,66 @@
 
 All bot management commands live under `/bot` (alias `/npc`). AI training is under `/ai`. Environment configuration is under `/botenvironment` (alias `/botenv`). Plugin info is under `/terminatorplus` (alias `/tplus`).
 
+## Canonical command layout
+
+New command paths use the following groups. The older flat paths documented below remain available as compatibility aliases.
+
+```text
+/bot spawn single|multiple
+/bot inspect list|info|weapons
+/bot move gather|scatter
+/bot settings combat-goal|target-mobs|target-player|target-region|show-in-player-list|auto-respawn|movement-v2|placement-material
+/bot equipment inventory|give|armor|loadout|mixed-loadout
+/bot preset save|apply|list|delete
+/bot debug behavior|combat|movement
+/bot admin reset
+/bot environment inspect material
+/bot environment solid-block add|remove|list|clear
+/bot environment custom-mob add|remove|list|clear
+/bot environment mob-list-mode get|set
+
+/ai spawn random|movement
+/ai train reinforcement|stop
+/ai brain status|load|save|reset
+/ai evaluate
+/ai inspect info
+```
+
+`/bot` still opens the management UI for players. `/botenvironment` and `/botenv` remain supported as legacy environment roots.
+
 ## Spawning
 
-### `/bot create <name> [skin] [loc]`
+### `/bot spawn single <name> [skin] [loc]`
 Spawn one bot. `skin` defaults to a Mojang lookup of `<name>`. `loc` is either a player name or `x y z [world]`.
 
-### `/bot multi <amount> <name> [skin] [loc]`
+### `/bot spawn multiple <amount> <name> [skin] [loc]`
 Spawn many bots at once.
 
-### `/bot reset`
+### `/bot admin reset`
 Remove every spawned bot. **Requires** `terminatorplus.admin`.
 
-## Inventory
+## Equipment
 
-### `/bot inventory <bot-name>` (alias `inv`)
+### `/bot equipment inventory <bot-name>` (legacy `/bot inventory`, alias `inv`)
 Open a 54-slot chest GUI that mirrors the bot's inventory. Edits save on close. See [Inventory GUI](Inventory-GUI).
 
-### `/bot give <item> [bot-name] [slot]`
+### `/bot equipment give <item> [bot-name] [slot]`
 - One arg: sets the default item for every bot.
 - Two args: drop the item into the first empty hotbar slot on the named bot.
 - Three args: place into the specified inventory slot. See the [Inventory GUI slot map](Inventory-GUI#slot-map).
 
-### `/bot place <material>`
+### `/bot settings placement-material <material>`
 Set the global block used by bot building and clutch placement. The default is `COBBLESTONE`.
 
-Example: `/bot place DIAMOND_BLOCK`
+Example: `/bot settings placement-material DIAMOND_BLOCK`
 
-### `/bot armor <tier>`
+### `/bot equipment armor <tier>`
 Apply an armor tier to every bot. Tiers: `none`, `leather`, `chain`, `gold`, `iron`, `diamond`, `netherite`.
 
-### `/bot loadout <name> [bot-name]`
+### `/bot equipment loadout <name> [bot-name]`
 Apply a predefined combat loadout. If `bot-name` is omitted, applies to all bots. See [Loadouts](Loadouts).
 
-### `/bot loadoutmix <mix> [bot-prefix]`
+### `/bot equipment mixed-loadout <mix> [bot-prefix]`
 Apply rotating combat loadouts across bots. Each bot gets a different loadout from the mix.
 
 | Mix | Loadouts |
@@ -47,7 +74,7 @@ Apply rotating combat loadouts across bots. Each bot gets a different loadout fr
 | `core` | `sword`, `axe`, `smp`, `mace`, `trident`, `spear`, `pot` |
 | `problem` / `combatdata` / `bugs` | `mace` (3x), `axe` (3x), `smp` (2x), `vanilla`, `hybrid` |
 
-### `/bot weapons [bot-name]`
+### `/bot inspect weapons [bot-name]`
 Print a per-bot summary of which combat behaviors its inventory unlocks. Useful for debugging "why isn't my bot using the trident?" (answer: usually, it's not in the hotbar).
 
 ## Presets
@@ -66,40 +93,55 @@ Delete a preset file. **Requires** `terminatorplus.admin`.
 
 ## Info
 
-### `/bot info <bot-name>`
+### `/bot inspect info <bot-name>`
 Print the bot's name, world, position, velocity.
 
-### `/bot count` (alias `list`)
+### `/bot inspect list` (legacy `/bot count`, alias `list`)
 Count bots by name.
 
 ## Settings
 
-### `/bot settings setgoal <goal>`
+### `/bot settings combat-goal <goal>`
 Change the global target-selection strategy. Goals: `PLAYER`, `NEAREST`, `NEAREST_PLAYER`, etc.
 
-### `/bot settings mobtarget <true|false>`
+### `/bot settings target-mobs <true|false>`
 Whether hostile mobs target spawned bots.
 
-### `/bot settings addplayerlist <true|false>`
+### `/bot settings show-in-player-list <true|false>`
 Whether newly-spawned bots appear in the tab list (and are affected by `@a`/`@p` selectors).
 
-### `/bot settings playertarget <name>`
+### `/bot settings target-player <name>`
 Set the player that bots focus on when goal is `PLAYER`.
 
-### `/bot settings region <x1> <y1> <z1> <x2> <y2> <z2> [<wX> <wY> <wZ>|strict]`
+### `/bot settings target-region <x1> <y1> <z1> <x2> <y2> <z2> [<wX> <wY> <wZ>|strict]`
 Set region for bot prioritization.
+
+### `/bot settings auto-respawn <true|false>`
+Enable or disable automatic bot respawning. **Requires** `terminatorplus.admin`.
+
+### `/bot settings movement-v2 <on|off|status>`
+Enable, disable, or inspect Movement V2. **Requires** `terminatorplus.admin`.
 
 ## Utility
 
-### `/bot gather` (alias `tpall`)
+### `/bot move gather` (legacy `/bot gather`, alias `tpall`)
 Teleport all bots to your location.
 
-### `/bot combatdebug <name|all> <on|off>` (aliases `cdbg`, `comatdebug`)
+### `/bot move scatter [radius]`
+Distribute living bots in a safe circular spread around your location.
+
+### `/bot debug behavior <expression>`
+Run a debugger behavior expression. **Requires** `terminatorplus.admin`.
+
+### `/bot debug movement [bot-name]`
+Show Movement V2 route and fallback status. **Requires** `terminatorplus.admin`.
+
+### `/bot debug combat <name|all> <on|off>` (legacy `/bot combatdebug`, aliases `cdbg`, `comatdebug`)
 Toggle combat trace logging for specific bots or all bots. Shows telemetry fields like `critPred`, `sweepPred`, `chargeAtVanillaAttack`, `targetHp`, and `targetHpDelta`. **Requires** `terminatorplus.admin`.
 
 ## AI Training (`/ai`)
 
-### `/ai reinforcement <population-size> <name> [skin] [mode-or-options] [round-minutes]`
+### `/ai train reinforcement <population-size> <name> [skin] [mode-or-options] [round-minutes]`
 Begin a training session. Must be run as a player.
 
 - Empty mode defaults to **movement-controller** training.
@@ -111,10 +153,10 @@ Begin a training session. Must be run as a player.
 - Mixed movement training ranks bots by the family they actually produced route samples for and autosaves eligible specialist brains, subject to `save-only-improved-brain`.
 - Use options such as `family=mace:mix=mace_curriculum` or `movement:family=mace:mix=mace_curriculum` for curriculum runs.
 
-### `/ai random <amount> <name> [skin] [loc]`
+### `/ai spawn random <amount> <name> [skin] [loc]`
 Spawn bots with random neural networks.
 
-### `/ai movement <amount> <name> [skin] [loc]`
+### `/ai spawn movement <amount> <name> [skin] [loc]`
 Spawn movement-controller bots that use the loaded movement brain bank.
 
 ### `/ai brain <status|load|save|reset> [bot-name]`
@@ -142,27 +184,26 @@ Useful variants:
 
 Use `/ai evaluate list` to print all variants and scenarios.
 
-### `/ai info <bot-name>`
+### `/ai inspect info <bot-name>`
 Display neural network info about a specific bot.
 
-### `/ai stop`
+### `/ai train stop`
 End the current AI training session.
 
-## Environment (`/botenvironment`, alias `/botenv`)
+## Environment (`/bot environment`; legacy `/botenvironment`, alias `/botenv`)
 
 Configure how bots understand blocks and mobs.
 
 | Subcommand | Purpose |
 | --- | --- |
-| `help [blocks\|mobs]` | Show help |
-| `getMaterial <x> <y> <z>` | Print the block material at a location (player only) |
-| `addSolid <material>` | Add a material to the "solid" list |
-| `removeSolid <material>` | Remove a material from the solid list |
-| `listSolids` / `clearSolids` | List or clear custom solid materials |
-| `addCustomMob <entity>` | Mark a mob as target-eligible |
-| `removeCustomMob <entity>` | Remove a custom mob |
-| `listCustomMobs` / `clearCustomMobs` | List or clear custom mobs |
-| `mobListType <mode>` | Change custom mob list behavior |
+| `inspect material <x> <y> <z>` | Print the block material at a location (player only) |
+| `solid-block add <material>` | Add a material to the "solid" list |
+| `solid-block remove <material>` | Remove a material from the solid list |
+| `solid-block list` / `clear` | List or clear custom solid materials |
+| `custom-mob add <entity>` | Mark a mob as target-eligible |
+| `custom-mob remove <entity>` | Remove a custom mob |
+| `custom-mob list` / `clear` | List or clear custom mobs |
+| `mob-list-mode get` / `set <mode>` | Read or change custom mob list behavior |
 
 ## Plugin
 

--- a/wiki/Release-Notes-6.2.2.md
+++ b/wiki/Release-Notes-6.2.2.md
@@ -1,0 +1,28 @@
+# TerminatorPlus 6.2.2 - Paper 26.2 Prerelease
+
+TerminatorPlus 6.2.2 reorganizes the command surface into predictable,
+discoverable groups while preserving the existing flat command paths for
+compatibility.
+
+## Highlights
+
+- Adds canonical grouped `/bot` paths for spawning, inspection, movement,
+  settings, equipment, presets, debugging, administration, and environment
+  management.
+- Adds grouped `/ai spawn`, `/ai train`, and `/ai inspect` paths while keeping
+  the existing AI commands available.
+- Updates tab completion and the bot management UI to follow the organized
+  command surface.
+- Normalizes target-goal input across case, hyphen, and underscore spelling.
+- Documents the canonical command layout in `wiki/Commands.md`.
+
+## Compatibility and scope
+
+- Existing flat command paths remain registered for compatibility.
+- This is a prerelease for Paper 26.2 and Java 25.
+- Gameplay behavior is unchanged by the command organization itself; live
+  Paper acceptance testing is still required before a production rollout.
+
+## Artifact
+
+`TerminatorPlus-6.2.2-BETA-mc26.2.jar`


### PR DESCRIPTION
## Summary
- organize `/bot`, `/ai`, and environment commands into canonical groups
- preserve legacy flat command paths for compatibility
- update completion, UI mappings, documentation, tests, and target-goal parsing
- prepare the `6.2.2-BETA-mc26.2` prerelease

## Validation
- `./gradlew build -q`
- command organization tests included