### PR TITLE
Make bot inventory editing transactional

### DIFF
--- a/TerminatorPlus-Plugin/src/main/java/net/nuggetmc/tplus/TerminatorPlus.java
+++ b/TerminatorPlus-Plugin/src/main/java/net/nuggetmc/tplus/TerminatorPlus.java
@@ -34,6 +34,7 @@ public class TerminatorPlus extends JavaPlugin {
     private CombatDirector combatDirector;
     private PresetManager presetManager;
     private BotManagementUI managementUI;
+    private BotInventoryListener inventoryListener;
 
     public static TerminatorPlus getInstance() {
         return instance;
@@ -71,6 +72,10 @@ public class TerminatorPlus extends JavaPlugin {
         return managementUI;
     }
 
+    public BotInventoryListener getInventoryListener() {
+        return inventoryListener;
+    }
+
     @Override
     public void onEnable() {
         instance = this;
@@ -85,6 +90,7 @@ public class TerminatorPlus extends JavaPlugin {
         this.manager = new BotManagerImpl();
         this.combatDirector = new CombatDirector();
         this.presetManager = new PresetManager(this);
+        this.inventoryListener = new BotInventoryListener(this);
         this.managementUI = new BotManagementUI(this);
         this.handler = new CommandHandler(this);
 
@@ -92,7 +98,7 @@ public class TerminatorPlus extends JavaPlugin {
         TerminatorPlusAPI.setInternalBridge(new InternalBridgeImpl());
 
         // Register event listeners
-        this.registerEvents(manager, new BotInventoryListener(this), managementUI);
+        this.registerEvents(manager, inventoryListener, managementUI);
 
         if (!correctVersion) {
             for (int i = 0; i < 20; i++) { // Kids are stupid so we need to make sure they see this
@@ -110,6 +116,9 @@ public class TerminatorPlus extends JavaPlugin {
         if (managementUI != null) {
             managementUI.shutdown();
         }
+        if (inventoryListener != null) {
+            inventoryListener.shutdown();
+        }
         if (manager != null) {
             manager.reset();
         }
@@ -117,6 +126,7 @@ public class TerminatorPlus extends JavaPlugin {
         combatDirector = null;
         presetManager = null;
         managementUI = null;
+        inventoryListener = null;
         manager = null;
         TerminatorPlusAPI.setBotManager(null);
         TerminatorPlusAPI.setInternalBridge(null);

--- a/TerminatorPlus-Plugin/src/main/java/net/nuggetmc/tplus/bot/gui/BotInventoryGUI.java
+++ b/TerminatorPlus-Plugin/src/main/java/net/nuggetmc/tplus/bot/gui/BotInventoryGUI.java
@@ -5,46 +5,67 @@ import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 import org.bukkit.Material;
 import org.bukkit.entity.Player;
+import org.bukkit.inventory.EquipmentSlot;
 import org.bukkit.inventory.Inventory;
 import org.bukkit.inventory.InventoryHolder;
 import org.bukkit.inventory.ItemStack;
-import org.bukkit.inventory.meta.ItemMeta;
 import org.bukkit.inventory.PlayerInventory;
+import org.bukkit.inventory.meta.ItemMeta;
+
+import java.util.Objects;
+import java.util.UUID;
 
 /**
- * Double-chest style GUI that mirrors a bot's full inventory.
+ * Transactional editor for one exact bot inventory.
  *
- * <p>Slot layout (54 slots / 6 rows):
- * <pre>
- *  0-8    -> hotbar (bot slots 0-8)
- *  9-17   -> storage row 1 (bot slots 9-17)
- *  18-26  -> storage row 2 (bot slots 18-26)
- *  27-35  -> storage row 3 (bot slots 27-35)
- *  36     -> head         (bot helmet)
- *  37     -> chest        (bot chestplate / elytra)
- *  38     -> legs         (bot leggings)
- *  39     -> feet         (bot boots)
- *  40     -> offhand      (bot offhand)
- *  41-44  -> filler (barrier glass)
- *  45-53  -> filler (barrier glass)
- * </pre>
+ * <p>The chest is a working copy. The bot is changed only by {@link #save()}.
+ * Closing the chest without saving discards the working copy.</p>
  */
 public final class BotInventoryGUI implements InventoryHolder {
 
     public static final int SIZE = 54;
+    public static final int EDITABLE_SLOTS = 41;
+    public static final int BOOTS_SLOT = 36;
+    public static final int LEGGINGS_SLOT = 37;
+    public static final int CHEST_SLOT = 38;
+    public static final int HELMET_SLOT = 39;
+    public static final int OFFHAND_SLOT = 40;
+
+    public static final int AUTO_EQUIP_SLOT = 45;
+    public static final int SAVE_SLOT = 48;
+    public static final int STATUS_SLOT = 49;
+    public static final int DISCARD_SLOT = 51;
+    public static final int CLOSE_SLOT = 53;
 
     private final Bot bot;
+    private final UUID viewerId;
+    private final ItemStack originalCursor;
     private final Inventory inventory;
+    private final EditState edits;
+    private boolean autoEquip;
+    private boolean closed;
 
-    public BotInventoryGUI(Bot bot) {
-        this.bot = bot;
+    BotInventoryGUI(Bot bot, Player viewer) {
+        this.bot = Objects.requireNonNull(bot, "bot");
+        Objects.requireNonNull(viewer, "viewer");
+        this.viewerId = viewer.getUniqueId();
+        this.originalCursor = cloneOrNull(viewer.getItemOnCursor());
         this.inventory = Bukkit.createInventory(this, SIZE,
-                ChatColor.GOLD + "Bot: " + ChatColor.YELLOW + bot.getBotName());
-        syncFromBot();
+                ChatColor.GOLD + "Inventory: " + ChatColor.YELLOW + bot.getBotName());
+        this.edits = EditState.capture(bot);
+        render();
     }
 
     public Bot getBot() {
         return bot;
+    }
+
+    public UUID getBotId() {
+        return bot.getUUID();
+    }
+
+    UUID getViewerId() {
+        return viewerId;
     }
 
     @Override
@@ -56,68 +77,241 @@ public final class BotInventoryGUI implements InventoryHolder {
         viewer.openInventory(inventory);
     }
 
-    /** Pull bot state into the GUI inventory (call when opening). */
-    public void syncFromBot() {
-        PlayerInventory pi = bot.getBukkitEntity().getInventory();
-        for (int i = 0; i < 36; i++) {
-            ItemStack it = pi.getItem(i);
-            inventory.setItem(i, it == null ? null : it.clone());
-        }
-        inventory.setItem(36, cloneOrNull(pi.getHelmet()));
-        inventory.setItem(37, cloneOrNull(pi.getChestplate()));
-        inventory.setItem(38, cloneOrNull(pi.getLeggings()));
-        inventory.setItem(39, cloneOrNull(pi.getBoots()));
-        inventory.setItem(40, cloneOrNull(pi.getItemInOffHand()));
-
-        ItemStack filler = buildFiller();
-        for (int i = 41; i < SIZE; i++) {
-            inventory.setItem(i, filler);
-        }
+    public boolean isAutoEquipEnabled() {
+        return autoEquip;
     }
 
-    private static ItemStack cloneOrNull(ItemStack it) {
-        return it == null ? null : it.clone();
+    void toggleAutoEquip() {
+        autoEquip = !autoEquip;
+        renderControls();
     }
 
-    /** Push GUI state back onto the bot (call when closing). */
-    public void syncToBot() {
-        bot.getBotInventory().applyMainInventorySnapshot(inventory.getContents());
+    public boolean hasChanges() {
+        return edits.changed(editableContents());
+    }
 
-        // Armor + offhand go through bot.setItem() so ClientboundSetEquipmentPacket is sent.
-        bot.setItem(safe(inventory.getItem(36)), org.bukkit.inventory.EquipmentSlot.HEAD);
-        bot.setItem(safe(inventory.getItem(37)), org.bukkit.inventory.EquipmentSlot.CHEST);
-        bot.setItem(safe(inventory.getItem(38)), org.bukkit.inventory.EquipmentSlot.LEGS);
-        bot.setItem(safe(inventory.getItem(39)), org.bukkit.inventory.EquipmentSlot.FEET);
-        bot.setItem(safe(inventory.getItem(40)), org.bukkit.inventory.EquipmentSlot.OFF_HAND);
+    /**
+     * Validate and apply the working copy. Returns false without changing the
+     * bot when the copy is invalid or this editor has already finished.
+     */
+    public boolean save() {
+        if (closed || !isBotUsable()) return false;
+        ItemStack[] snapshot = editableContents();
+        if (validationError(snapshot) != null) return false;
 
-        // Auto-organise: move items into the best slots and select the primary weapon.
-        bot.getBotInventory().autoEquip();
-        // A GUI save is a deliberate authoritative edit - lock out the 40-tick
-        // movement-kit refill so the user's "I removed the pearls on purpose"
-        // decision survives the next ensureMovementKit tick.
+        bot.getBotInventory().applyMainInventorySnapshot(snapshot);
+        bot.setItem(safe(snapshot[BOOTS_SLOT]), EquipmentSlot.FEET);
+        bot.setItem(safe(snapshot[LEGGINGS_SLOT]), EquipmentSlot.LEGS);
+        bot.setItem(safe(snapshot[CHEST_SLOT]), EquipmentSlot.CHEST);
+        bot.setItem(safe(snapshot[HELMET_SLOT]), EquipmentSlot.HEAD);
+        bot.setItemOffhand(safe(snapshot[OFFHAND_SLOT]));
+
+        if (autoEquip) {
+            bot.getBotInventory().autoEquip();
+        } else {
+            bot.getBotInventory().setSelectedHotbarSlot(edits.selectedHotbarSlot());
+            bot.getBotInventory().refreshSelectedItem();
+        }
         bot.getBotInventory().markLoadoutApplied();
+        closed = true;
+        return true;
     }
 
-    /** Slots in the GUI that are decorative/locked. */
+    /** Discard the working copy and restore the cursor captured on open. */
+    void discard(Player viewer) {
+        if (closed) return;
+        if (viewer != null && viewerId.equals(viewer.getUniqueId())) {
+            viewer.setItemOnCursor(cloneOrNull(originalCursor));
+        }
+        closed = true;
+    }
+
+    boolean isClosed() {
+        return closed;
+    }
+
+    boolean isBotUsable() {
+        try {
+            return bot.isBotAlive();
+        } catch (RuntimeException ignored) {
+            return false;
+        }
+    }
+
+    ItemStack[] editableContents() {
+        ItemStack[] contents = new ItemStack[EDITABLE_SLOTS];
+        for (int i = 0; i < EDITABLE_SLOTS; i++) {
+            ItemStack item = inventory.getItem(i);
+            contents[i] = item == null ? null : item.clone();
+        }
+        return contents;
+    }
+
+    private void render() {
+        inventory.clear();
+        PlayerInventory playerInventory = bot.getBukkitEntity().getInventory();
+        for (int i = 0; i < 36; i++) {
+            inventory.setItem(i, cloneOrNull(playerInventory.getItem(i)));
+        }
+        inventory.setItem(BOOTS_SLOT, cloneOrNull(playerInventory.getBoots()));
+        inventory.setItem(LEGGINGS_SLOT, cloneOrNull(playerInventory.getLeggings()));
+        inventory.setItem(CHEST_SLOT, cloneOrNull(playerInventory.getChestplate()));
+        inventory.setItem(HELMET_SLOT, cloneOrNull(playerInventory.getHelmet()));
+        inventory.setItem(OFFHAND_SLOT, cloneOrNull(playerInventory.getItemInOffHand()));
+
+        ItemStack filler = filler();
+        for (int slot = EDITABLE_SLOTS; slot < SIZE; slot++) {
+            if (!isControlSlot(slot)) inventory.setItem(slot, filler.clone());
+        }
+        renderControls();
+    }
+
+    private void renderControls() {
+        inventory.setItem(AUTO_EQUIP_SLOT, item(
+                autoEquip ? Material.LIME_DYE : Material.GRAY_DYE,
+                "Auto-equip on save: " + (autoEquip ? "ON" : "OFF"),
+                autoEquip ? "Save will use the deterministic combat layout."
+                        : "Save keeps every item in its edited slot."));
+        inventory.setItem(SAVE_SLOT, item(Material.LIME_WOOL, "Save changes",
+                "Apply the edited 41-slot inventory to " + bot.getBotName()));
+        inventory.setItem(STATUS_SLOT, item(Material.PAPER, "Bot: " + bot.getBotName(),
+                "UUID: " + bot.getUUID(),
+                "Changes stay local until Save.",
+                "Auto-equip: " + (autoEquip ? "on" : "off")));
+        inventory.setItem(DISCARD_SLOT, item(Material.RED_WOOL, "Discard changes",
+                "Close without changing " + bot.getBotName()));
+        inventory.setItem(CLOSE_SLOT, item(Material.BARRIER, "Close (discard)",
+                "Unsaved changes will be discarded."));
+    }
+
+    static boolean isEditableSlot(int slot) {
+        return slot >= 0 && slot < EDITABLE_SLOTS;
+    }
+
+    static boolean isControlSlot(int slot) {
+        return slot == AUTO_EQUIP_SLOT || slot == SAVE_SLOT || slot == STATUS_SLOT
+                || slot == DISCARD_SLOT || slot == CLOSE_SLOT;
+    }
+
+    /** Slots that are decorative and cannot receive or provide items. */
     public static boolean isFillerSlot(int slot) {
-        return slot >= 41 && slot < SIZE;
+        return slot >= EDITABLE_SLOTS && slot < SIZE && !isControlSlot(slot);
     }
 
     public static boolean isArmorOrOffhand(int slot) {
-        return slot >= 36 && slot < 41;
+        return slot >= BOOTS_SLOT && slot <= OFFHAND_SLOT;
     }
 
-    private static ItemStack safe(ItemStack it) {
-        return it == null ? new ItemStack(Material.AIR) : it;
+    static Control actionForSlot(int slot) {
+        if (slot == AUTO_EQUIP_SLOT) return Control.AUTO_EQUIP;
+        if (slot == SAVE_SLOT) return Control.SAVE;
+        if (slot == DISCARD_SLOT) return Control.DISCARD;
+        if (slot == CLOSE_SLOT) return Control.CLOSE;
+        return null;
     }
 
-    private static ItemStack buildFiller() {
-        ItemStack it = new ItemStack(Material.GRAY_STAINED_GLASS_PANE);
-        ItemMeta meta = it.getItemMeta();
-        if (meta != null) {
-            meta.setDisplayName(" ");
-            it.setItemMeta(meta);
+    /** Check the only slots that a chest inventory cannot validate itself. */
+    static String validationError(ItemStack[] contents) {
+        if (contents == null || contents.length < EDITABLE_SLOTS) return "The editor contents are incomplete.";
+        for (int slot = BOOTS_SLOT; slot <= HELMET_SLOT; slot++) {
+            if (!isValidItemForSlot(slot, contents[slot])) {
+                return "That item cannot be placed in equipment slot " + slot + ".";
+            }
         }
-        return it;
+        return null;
+    }
+
+    static boolean isValidItemForSlot(int slot, ItemStack item) {
+        return item == null || isValidMaterialForSlot(slot, item.getType());
+    }
+
+    static boolean isValidMaterialForSlot(int slot, Material material) {
+        if (material == null || material == Material.AIR || material == Material.CAVE_AIR
+                || material == Material.VOID_AIR || !isEditableSlot(slot)) return true;
+        String name = material.name();
+        return switch (slot) {
+            case BOOTS_SLOT -> name.endsWith("_BOOTS");
+            case LEGGINGS_SLOT -> name.endsWith("_LEGGINGS");
+            case CHEST_SLOT -> name.endsWith("_CHESTPLATE") || name.equals("ELYTRA");
+            case HELMET_SLOT -> name.endsWith("_HELMET") || name.equals("CARVED_PUMPKIN");
+            default -> true;
+        };
+    }
+
+    static final class EditState {
+        private final ItemStack[] original;
+        private final int selectedHotbarSlot;
+
+        EditState(ItemStack[] original, int selectedHotbarSlot) {
+            this.original = copy(original, EDITABLE_SLOTS);
+            this.selectedHotbarSlot = selectedHotbarSlot;
+        }
+
+        static EditState capture(Bot bot) {
+            PlayerInventory inventory = bot.getBukkitEntity().getInventory();
+            ItemStack[] snapshot = new ItemStack[EDITABLE_SLOTS];
+            for (int i = 0; i < 36; i++) snapshot[i] = inventory.getItem(i);
+            snapshot[BOOTS_SLOT] = inventory.getBoots();
+            snapshot[LEGGINGS_SLOT] = inventory.getLeggings();
+            snapshot[CHEST_SLOT] = inventory.getChestplate();
+            snapshot[HELMET_SLOT] = inventory.getHelmet();
+            snapshot[OFFHAND_SLOT] = inventory.getItemInOffHand();
+            return new EditState(snapshot, bot.getBotInventory().getSelectedHotbarSlot());
+        }
+
+        boolean changed(ItemStack[] current) {
+            ItemStack[] normalized = copy(current, EDITABLE_SLOTS);
+            for (int i = 0; i < EDITABLE_SLOTS; i++) {
+                if (!Objects.equals(original[i], normalized[i])) return true;
+            }
+            return false;
+        }
+
+        int selectedHotbarSlot() {
+            return selectedHotbarSlot;
+        }
+    }
+
+    enum Control {
+        AUTO_EQUIP,
+        SAVE,
+        DISCARD,
+        CLOSE
+    }
+
+    private static ItemStack[] copy(ItemStack[] source, int length) {
+        ItemStack[] result = new ItemStack[length];
+        if (source == null) return result;
+        for (int i = 0; i < length && i < source.length; i++) {
+            result[i] = cloneOrNull(source[i]);
+        }
+        return result;
+    }
+
+    private static ItemStack cloneOrNull(ItemStack item) {
+        return item == null ? null : item.clone();
+    }
+
+    private static ItemStack safe(ItemStack item) {
+        return item == null || item.getType().isAir() ? new ItemStack(Material.AIR) : item.clone();
+    }
+
+    private static ItemStack filler() {
+        return item(Material.GRAY_STAINED_GLASS_PANE, " ");
+    }
+
+    private static ItemStack item(Material material, String name, String... lore) {
+        ItemStack item = new ItemStack(material);
+        ItemMeta meta = item.getItemMeta();
+        if (meta != null) {
+            meta.setDisplayName(ChatColor.RESET + name);
+            if (lore.length > 0) {
+                java.util.List<String> lines = new java.util.ArrayList<>(lore.length);
+                for (String line : lore) lines.add(ChatColor.GRAY + line);
+                meta.setLore(lines);
+            }
+            item.setItemMeta(meta);
+        }
+        return item;
     }
 }

--- a/TerminatorPlus-Plugin/src/main/java/net/nuggetmc/tplus/bot/gui/BotInventoryListener.java
+++ b/TerminatorPlus-Plugin/src/main/java/net/nuggetmc/tplus/bot/gui/BotInventoryListener.java
@@ -1,75 +1,344 @@
 package net.nuggetmc.tplus.bot.gui;
 
 import net.nuggetmc.tplus.TerminatorPlus;
-import org.bukkit.event.Event;
+import net.nuggetmc.tplus.api.Terminator;
+import net.nuggetmc.tplus.bot.Bot;
+import org.bukkit.ChatColor;
+import org.bukkit.Bukkit;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
+import org.bukkit.event.inventory.ClickType;
 import org.bukkit.event.inventory.InventoryClickEvent;
 import org.bukkit.event.inventory.InventoryCloseEvent;
 import org.bukkit.event.inventory.InventoryDragEvent;
+import org.bukkit.event.inventory.InventoryMoveItemEvent;
+import org.bukkit.event.player.PlayerKickEvent;
+import org.bukkit.event.player.PlayerQuitEvent;
+import org.bukkit.entity.Player;
 import org.bukkit.inventory.Inventory;
+import org.bukkit.scheduler.BukkitTask;
 
-/**
- * Blocks edits to the decorative filler slots of {@link BotInventoryGUI}
- * and writes changes back to the bot when the viewer closes the GUI.
- */
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+import java.util.UUID;
+
+/** Owns transactional bot-inventory editors and their event boundaries. */
 public final class BotInventoryListener implements Listener {
 
+    static final String MANAGE_PERMISSION = "terminatorplus.manage";
+    private static final long WATCH_INTERVAL_TICKS = 5L;
+
     private final TerminatorPlus plugin;
+    private final Map<UUID, BotInventoryGUI> editorsByViewer = new HashMap<>();
+    private final Map<UUID, BotInventoryGUI> editorsByBot = new HashMap<>();
+    private final EditorLocks locks = new EditorLocks();
+    private BukkitTask watchTask;
 
     public BotInventoryListener(TerminatorPlus plugin) {
-        this.plugin = plugin;
+        this.plugin = Objects.requireNonNull(plugin, "plugin");
+        if (Bukkit.isPrimaryThread()) {
+            watchTask = Bukkit.getScheduler().runTaskTimer(plugin, this::closeUnavailableEditors,
+                    WATCH_INTERVAL_TICKS, WATCH_INTERVAL_TICKS);
+        }
+    }
+
+    /** Open an exact bot instance, acquiring the one-editor-per-bot lock. */
+    public boolean open(Player viewer, Bot bot) {
+        if (viewer == null || bot == null) return false;
+        if (!viewer.hasPermission(MANAGE_PERMISSION)) {
+            viewer.sendMessage(ChatColor.RED + "You do not have permission to edit bot inventories.");
+            return false;
+        }
+        if (!isCurrentBot(bot) || !isAlive(bot)) {
+            viewer.sendMessage(ChatColor.RED + "That bot is no longer available.");
+            return false;
+        }
+
+        UUID viewerId = viewer.getUniqueId();
+        UUID botId = bot.getUUID();
+        BotInventoryGUI existingBotEditor = editorsByBot.get(botId);
+        if (existingBotEditor != null && !viewerId.equals(existingBotEditor.getViewerId())) {
+            viewer.sendMessage(ChatColor.YELLOW + "That bot is already being edited by another player.");
+            return false;
+        }
+
+        BotInventoryGUI existingViewerEditor = editorsByViewer.get(viewerId);
+        if (existingViewerEditor != null) {
+            closeEditor(existingViewerEditor, "Previous inventory changes were discarded.", true);
+        }
+        if (!locks.tryAcquire(botId, viewerId)) {
+            viewer.sendMessage(ChatColor.YELLOW + "That bot is already being edited.");
+            return false;
+        }
+
+        try {
+            BotInventoryGUI gui = new BotInventoryGUI(bot, viewer);
+            editorsByViewer.put(viewerId, gui);
+            editorsByBot.put(botId, gui);
+            gui.open(viewer);
+            return true;
+        } catch (RuntimeException openFailure) {
+            BotInventoryGUI registered = editorsByViewer.remove(viewerId);
+            if (registered != null) editorsByBot.remove(botId, registered);
+            locks.release(botId, viewerId);
+            viewer.sendMessage(ChatColor.RED + "The bot inventory editor could not be opened.");
+            return false;
+        }
     }
 
     @EventHandler(priority = EventPriority.HIGHEST, ignoreCancelled = false)
     public void onClick(InventoryClickEvent event) {
         Inventory top = event.getView().getTopInventory();
-        if (!(top.getHolder() instanceof BotInventoryGUI)) return;
+        if (!(top.getHolder() instanceof BotInventoryGUI gui)) return;
 
-        // Filler slots: lock down hard.
-        if (event.getClickedInventory() == top && BotInventoryGUI.isFillerSlot(event.getRawSlot())) {
-            event.setCancelled(true);
-            event.setResult(Event.Result.DENY);
+        event.setCancelled(true);
+        if (!(event.getWhoClicked() instanceof Player player) || !owns(gui, player)) return;
+        if (!checkPermission(gui, player)) return;
+        if (!isCurrentBot(gui.getBot())) {
+            closeEditor(gui, "The bot disappeared; inventory changes were discarded.", true);
             return;
         }
 
-        // For every other slot in our GUI, force-allow the click in case another plugin
-        // (or Paper's protection layer) tried to cancel it.
+        if (event.getClickedInventory() != top || event.getRawSlot() < 0
+                || event.getRawSlot() >= top.getSize()) return;
+        if (isProhibitedClick(event.getClick())) {
+            player.sendMessage(ChatColor.YELLOW + "Use a normal left or right click in the editor.");
+            return;
+        }
+
+        BotInventoryGUI.Control control = BotInventoryGUI.actionForSlot(event.getRawSlot());
+        if (control != null) {
+            handleControl(gui, player, control);
+            return;
+        }
+        if (!BotInventoryGUI.isEditableSlot(event.getRawSlot())) return;
+        if (!BotInventoryGUI.isValidItemForSlot(event.getRawSlot(), event.getCursor())) {
+            player.sendMessage(ChatColor.RED + "That item does not fit in this equipment slot.");
+            return;
+        }
+
+        // Only ordinary left/right clicks reach Bukkit's chest transaction.
         event.setCancelled(false);
-        event.setResult(Event.Result.ALLOW);
     }
 
     @EventHandler(priority = EventPriority.HIGHEST, ignoreCancelled = false)
     public void onDrag(InventoryDragEvent event) {
         Inventory top = event.getView().getTopInventory();
-        if (!(top.getHolder() instanceof BotInventoryGUI)) return;
+        if (!(top.getHolder() instanceof BotInventoryGUI gui)) return;
 
-        for (int slot : event.getRawSlots()) {
-            if (slot < top.getSize() && BotInventoryGUI.isFillerSlot(slot)) {
-                event.setCancelled(true);
-                event.setResult(Event.Result.DENY);
-                return;
+        event.setCancelled(true);
+        if (event.getWhoClicked() instanceof Player player && owns(gui, player)) {
+            if (checkPermission(gui, player) && !isCurrentBot(gui.getBot())) {
+                closeEditor(gui, "The bot disappeared; inventory changes were discarded.", true);
             }
         }
+    }
 
-        event.setCancelled(false);
-        event.setResult(Event.Result.ALLOW);
+    @EventHandler(priority = EventPriority.HIGHEST, ignoreCancelled = false)
+    public void onMoveItem(InventoryMoveItemEvent event) {
+        if (event.getSource().getHolder() instanceof BotInventoryGUI
+                || event.getDestination().getHolder() instanceof BotInventoryGUI) {
+            event.setCancelled(true);
+        }
     }
 
     @EventHandler
     public void onClose(InventoryCloseEvent event) {
-        Inventory top = event.getView().getTopInventory();
-        if (!(top.getHolder() instanceof BotInventoryGUI gui)) return;
+        if (!(event.getView().getTopInventory().getHolder() instanceof BotInventoryGUI gui)) return;
+        if (!(event.getPlayer() instanceof Player player) || !owns(gui, player)) return;
+        closeEditor(gui, gui.hasChanges()
+                ? "Inventory changes discarded. Use Save before closing to keep edits."
+                : "Inventory editor closed.", false);
+    }
 
-        if (!gui.getBot().isBotAlive()) return;
-        gui.syncToBot();
+    @EventHandler
+    public void onPlayerQuit(PlayerQuitEvent event) {
+        closeForViewer(event.getPlayer().getUniqueId());
+    }
 
-        // Propagate the same inventory to every other bot with the same name.
-        String name = gui.getBot().getBotName();
-        net.nuggetmc.tplus.bot.Bot source = gui.getBot();
-        plugin.getManager().getAllByName(name).stream()
-                .filter(b -> b != source && b.isBotAlive())
-                .forEach(b -> source.getBotInventory().copyInventoryTo(b));
+    @EventHandler
+    public void onPlayerKick(PlayerKickEvent event) {
+        closeForViewer(event.getPlayer().getUniqueId());
+    }
+
+    /** Close every editor for a bot that was removed or replaced. */
+    public void closeForBot(Bot bot) {
+        if (bot == null) return;
+        BotInventoryGUI gui = editorsByBot.get(bot.getUUID());
+        if (gui != null && gui.getBot() == bot) {
+            closeEditor(gui, "The bot was removed; inventory changes were discarded.", true);
+        }
+    }
+
+    /** Release all locks and stop the watcher during plugin shutdown. */
+    public void shutdown() {
+        if (watchTask != null && !watchTask.isCancelled()) watchTask.cancel();
+        watchTask = null;
+        for (BotInventoryGUI gui : new ArrayList<>(editorsByViewer.values())) {
+            closeEditor(gui, null, true);
+        }
+        editorsByViewer.clear();
+        editorsByBot.clear();
+        locks.clear();
+    }
+
+    static boolean isProhibitedClick(ClickType click) {
+        return click != ClickType.LEFT && click != ClickType.RIGHT;
+    }
+
+    static final class EditorLocks {
+        private final Map<UUID, UUID> botOwners = new HashMap<>();
+        private final Map<UUID, UUID> viewerBots = new HashMap<>();
+
+        boolean tryAcquire(UUID botId, UUID viewerId) {
+            if (botId == null || viewerId == null || botOwners.containsKey(botId)
+                    || viewerBots.containsKey(viewerId)) return false;
+            botOwners.put(botId, viewerId);
+            viewerBots.put(viewerId, botId);
+            return true;
+        }
+
+        void release(UUID botId, UUID viewerId) {
+            if (botId == null || viewerId == null) return;
+            if (viewerId.equals(botOwners.get(botId))) botOwners.remove(botId);
+            if (botId.equals(viewerBots.get(viewerId))) viewerBots.remove(viewerId);
+        }
+
+        boolean owns(UUID botId, UUID viewerId) {
+            return botId != null && viewerId != null && viewerId.equals(botOwners.get(botId));
+        }
+
+        boolean locked(UUID botId) {
+            return botOwners.containsKey(botId);
+        }
+
+        int size() {
+            return botOwners.size();
+        }
+
+        void clear() {
+            botOwners.clear();
+            viewerBots.clear();
+        }
+    }
+
+    private void handleControl(BotInventoryGUI gui, Player player, BotInventoryGUI.Control control) {
+        switch (control) {
+            case AUTO_EQUIP -> {
+                gui.toggleAutoEquip();
+                player.sendMessage(ChatColor.YELLOW + "Auto-equip on save is now "
+                        + (gui.isAutoEquipEnabled() ? "on" : "off") + ".");
+            }
+            case SAVE -> save(gui, player);
+            case DISCARD, CLOSE -> discard(gui, player);
+        }
+    }
+
+    private void save(BotInventoryGUI gui, Player player) {
+        if (!checkPermission(gui, player)) return;
+        if (!isCurrentBot(gui.getBot())) {
+            closeEditor(gui, "The bot disappeared; inventory changes were discarded.", true);
+            return;
+        }
+        String error = BotInventoryGUI.validationError(gui.editableContents());
+        if (error != null) {
+            player.sendMessage(ChatColor.RED + "Save rejected: " + error);
+            return;
+        }
+        try {
+            if (!gui.save()) {
+                player.sendMessage(ChatColor.RED + "Save rejected because the bot is no longer available.");
+                closeEditor(gui, "Inventory changes were discarded.", true);
+                return;
+            }
+        } catch (RuntimeException errorDuringSave) {
+            player.sendMessage(ChatColor.RED + "Save failed while applying the inventory; the bot may be partially updated.");
+            return;
+        }
+        unregister(gui);
+        player.sendMessage(ChatColor.GREEN + "Inventory saved for " + ChatColor.YELLOW
+                + gui.getBot().getBotName() + ChatColor.GREEN + ".");
+        if (player.getOpenInventory().getTopInventory().getHolder() == gui) player.closeInventory();
+    }
+
+    private void discard(BotInventoryGUI gui, Player player) {
+        unregister(gui);
+        gui.discard(player);
+        player.sendMessage(ChatColor.YELLOW + "Inventory changes discarded for "
+                + ChatColor.GOLD + gui.getBot().getBotName() + ChatColor.YELLOW + ".");
+        if (player.getOpenInventory().getTopInventory().getHolder() == gui) player.closeInventory();
+    }
+
+    private boolean checkPermission(BotInventoryGUI gui, Player player) {
+        if (player.hasPermission(MANAGE_PERMISSION)) return true;
+        closeEditor(gui, "You no longer have permission to edit bot inventories.", true);
+        return false;
+    }
+
+    private boolean owns(BotInventoryGUI gui, Player player) {
+        return gui != null && player != null && gui.getViewerId() != null
+                && gui.getViewerId().equals(player.getUniqueId())
+                && locks.owns(gui.getBotId(), player.getUniqueId())
+                && editorsByViewer.get(player.getUniqueId()) == gui;
+    }
+
+    private boolean isCurrentBot(Bot bot) {
+        if (bot == null || plugin.getManager() == null) return false;
+        try {
+            for (Terminator candidate : plugin.getManager().fetch()) {
+                if (candidate instanceof Bot current && current.getUUID().equals(bot.getUUID())) {
+                    return current == bot;
+                }
+            }
+        } catch (RuntimeException ignored) {
+            return false;
+        }
+        return false;
+    }
+
+    private static boolean isAlive(Bot bot) {
+        try {
+            return bot != null && bot.isBotAlive();
+        } catch (RuntimeException ignored) {
+            return false;
+        }
+    }
+
+    private void closeUnavailableEditors() {
+        for (BotInventoryGUI gui : new ArrayList<>(editorsByViewer.values())) {
+            if (!isCurrentBot(gui.getBot()) || !gui.isBotUsable()) {
+                closeEditor(gui, "The bot disappeared; inventory changes were discarded.", true);
+            }
+        }
+    }
+
+    private void closeForViewer(UUID viewerId) {
+        BotInventoryGUI gui = editorsByViewer.get(viewerId);
+        if (gui != null) closeEditor(gui, null, false);
+    }
+
+    private void closeEditor(BotInventoryGUI gui, String message, boolean closeInventory) {
+        if (!unregister(gui)) return;
+        Player player = Bukkit.getPlayer(gui.getViewerId());
+        gui.discard(player);
+        if (player != null && message != null) player.sendMessage(ChatColor.YELLOW + message);
+        if (closeInventory && player != null
+                && player.getOpenInventory().getTopInventory().getHolder() == gui) {
+            player.closeInventory();
+        }
+    }
+
+    private boolean unregister(BotInventoryGUI gui) {
+        if (gui == null) return false;
+        boolean registered = editorsByViewer.get(gui.getViewerId()) == gui
+                || editorsByBot.get(gui.getBotId()) == gui;
+        if (!registered) return false;
+        editorsByViewer.remove(gui.getViewerId(), gui);
+        editorsByBot.remove(gui.getBotId(), gui);
+        locks.release(gui.getBotId(), gui.getViewerId());
+        return true;
     }
 }

--- a/TerminatorPlus-Plugin/src/main/java/net/nuggetmc/tplus/bot/gui/BotManagementUI.java
+++ b/TerminatorPlus-Plugin/src/main/java/net/nuggetmc/tplus/bot/gui/BotManagementUI.java
@@ -2,6 +2,7 @@ package net.nuggetmc.tplus.bot.gui;
 
 import net.nuggetmc.tplus.TerminatorPlus;
 import net.nuggetmc.tplus.api.Terminator;
+import net.nuggetmc.tplus.bot.Bot;
 import net.nuggetmc.tplus.bot.navigation.MovementV2Settings;
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
@@ -52,6 +53,7 @@ public final class BotManagementUI implements Listener {
     static final String ADMIN_PERMISSION = "terminatorplus.admin";
     static final int BOT_PAGE_SIZE = 28;
     private static final int MAX_PROMPT_LENGTH = 256;
+    private static final long PROMPT_TIMEOUT_TICKS = 20L * 60L;
     private static final String TITLE = ChatColor.GOLD + "TerminatorPlus Management";
 
     private final TerminatorPlus plugin;
@@ -81,6 +83,10 @@ public final class BotManagementUI implements Listener {
     /** Opens or reuses the management session and always starts at the main page. */
     public void open(Player player) {
         if (player == null || shutdown || plugin == null) return;
+        if (!player.hasPermission(MANAGE_PERMISSION)) {
+            player.sendMessage(ChatColor.RED + "You do not have permission to use bot management.");
+            return;
+        }
         if (!Bukkit.isPrimaryThread()) {
             Bukkit.getScheduler().runTask(plugin, () -> open(player));
             return;
@@ -93,7 +99,7 @@ public final class BotManagementUI implements Listener {
             sessions.put(playerId, session);
             lifecycle.sessionOpened();
         }
-        prompts.remove(playerId);
+        clearPrompt(playerId);
         session.resetForOpen();
         render(session);
         player.openInventory(session.inventory);
@@ -126,6 +132,11 @@ public final class BotManagementUI implements Listener {
         event.setCancelled(true);
         if (!(event.getWhoClicked() instanceof Player player)
                 || !session.playerId.equals(player.getUniqueId())) return;
+        if (!player.hasPermission(MANAGE_PERMISSION)) {
+            player.sendMessage(ChatColor.RED + "You no longer have permission to use bot management.");
+            removeSession(session.playerId, true);
+            return;
+        }
 
         Button button = session.buttons.get(event.getRawSlot());
         if (button != null) handle(session, button);
@@ -133,10 +144,16 @@ public final class BotManagementUI implements Listener {
 
     @EventHandler
     public void onInventoryDrag(InventoryDragEvent event) {
-        if (event.getView().getTopInventory().getHolder() instanceof Session) {
+        if (event.getView().getTopInventory().getHolder() instanceof Session session) {
             // A drag can contain both top and bottom raw slots; cancel the
             // entire operation rather than trying to filter individual slots.
             event.setCancelled(true);
+            if (event.getWhoClicked() instanceof Player player
+                    && session.playerId.equals(player.getUniqueId())
+                    && !player.hasPermission(MANAGE_PERMISSION)) {
+                player.sendMessage(ChatColor.RED + "You no longer have permission to use bot management.");
+                removeSession(session.playerId, true);
+            }
         }
     }
 
@@ -161,12 +178,13 @@ public final class BotManagementUI implements Listener {
     @EventHandler
     public void onChat(AsyncPlayerChatEvent event) {
         UUID playerId = event.getPlayer().getUniqueId();
-        if (prompts.get(playerId) == null) return;
+        PendingPrompt pending = prompts.get(playerId);
+        if (pending == null) return;
 
         event.setCancelled(true);
         if (plugin == null) return;
         String message = event.getMessage();
-        Bukkit.getScheduler().runTask(plugin, () -> finishPrompt(playerId, message));
+        Bukkit.getScheduler().runTask(plugin, () -> finishPrompt(playerId, pending, message));
     }
 
     private void handle(Session session, Button button) {
@@ -181,9 +199,11 @@ public final class BotManagementUI implements Listener {
             case OPEN_ENVIRONMENT -> page(session, Page.ENVIRONMENT, "Environment");
             case OPEN_HELP -> page(session, Page.HELP, "Help and plugin info");
             case BACK -> back(session);
+            case PREVIOUS_PAGE -> previousBotPage(session);
             case NEXT_PAGE -> nextBotPage(session);
             case CLOSE -> closeSession(session.playerId, true);
             case SELECT_BOT -> selectBot(session, button.payload());
+            case BOT_INVENTORY -> openSelectedInventory(session);
             case CONFIRM -> confirm(session);
             case CANCEL -> cancelConfirmation(session);
             default -> runAction(session, button);
@@ -197,6 +217,11 @@ public final class BotManagementUI implements Listener {
         Player player = Bukkit.getPlayer(session.playerId);
         if (player == null) {
             removeSession(session.playerId, false);
+            return;
+        }
+        if (!player.hasPermission(MANAGE_PERMISSION)) {
+            player.sendMessage(ChatColor.RED + "You no longer have permission to use bot management.");
+            removeSession(session.playerId, true);
             return;
         }
         if (action.requiresAdmin() && !player.hasPermission(ADMIN_PERMISSION)) {
@@ -252,36 +277,86 @@ public final class BotManagementUI implements Listener {
     private void nextBotPage(Session session) {
         if (session.state.page != Page.BOTS) return;
         int pageCount = pageCount(currentBots().size());
-        if (session.state.pageIndex + 1 >= pageCount) return;
-        session.state.pageIndex++;
+        if (session.state.pageIndex() + 1 >= pageCount) {
+            session.status = "Already on the last bot page (" + pageCount + ").";
+            render(session);
+            return;
+        }
+        session.state.setPageIndex(session.state.pageIndex() + 1, pageCount);
         session.status = "Bot page " + (session.state.pageIndex + 1) + "/" + pageCount;
         render(session);
     }
 
+    private void previousBotPage(Session session) {
+        if (session.state.page != Page.BOTS) return;
+        int pageCount = pageCount(currentBots().size());
+        if (session.state.pageIndex() <= 0) {
+            session.status = "Already on the first bot page (" + pageCount + ").";
+            render(session);
+            return;
+        }
+        session.state.setPageIndex(session.state.pageIndex() - 1, pageCount);
+        session.status = "Bot page " + (session.state.pageIndex() + 1) + "/" + pageCount;
+        render(session);
+    }
+
+    private void openSelectedInventory(Session session) {
+        Player player = Bukkit.getPlayer(session.playerId);
+        Terminator selected = findBot(session.selectedBot);
+        if (!(selected instanceof Bot bot)) {
+            setStatus(session, "The selected bot is no longer active.");
+            return;
+        }
+        if (plugin == null || plugin.getInventoryListener() == null) {
+            setStatus(session, "The bot inventory editor is unavailable.");
+            return;
+        }
+        if (player == null || !player.hasPermission(MANAGE_PERMISSION)) {
+            removeSession(session.playerId, true);
+            return;
+        }
+        if (plugin.getInventoryListener().open(player, bot)) {
+            removeSession(session.playerId, false);
+        }
+    }
+
     private void beginPrompt(Session session, UiAction action, String hint) {
-        prompts.put(session.playerId, new PendingPrompt(action, hint));
+        PendingPrompt previous = prompts.remove(session.playerId);
+        if (previous != null) {
+            previous.cancel();
+            Player player = Bukkit.getPlayer(session.playerId);
+            if (player != null) player.sendMessage(ChatColor.YELLOW + "Previous prompt cancelled.");
+        }
+        PendingPrompt pending = new PendingPrompt(action, hint);
+        prompts.put(session.playerId, pending);
         session.awaitingPrompt = true;
         session.status = "Waiting for chat input";
         Player player = Bukkit.getPlayer(session.playerId);
         if (player != null) {
             player.sendMessage(ChatColor.YELLOW + "Enter " + hint + ChatColor.GRAY + ", or type cancel.");
         }
+        if (plugin != null) {
+            pending.timeoutTask = Bukkit.getScheduler().runTaskLater(plugin,
+                    () -> expirePrompt(session.playerId, pending), PROMPT_TIMEOUT_TICKS);
+        }
         render(session);
         if (player != null) player.closeInventory();
         stopRefreshIfNoOpenSessions();
     }
 
-    private void finishPrompt(UUID playerId, String message) {
+    private void finishPrompt(UUID playerId, PendingPrompt pending, String message) {
         Session session = sessions.get(playerId);
-        PendingPrompt pending = prompts.get(playerId);
         Player player = Bukkit.getPlayer(playerId);
-        if (session == null || pending == null || player == null) {
-            prompts.remove(playerId);
+        if (!isCurrentPrompt(prompts.get(playerId), pending)) return;
+        if (session == null || player == null) {
+            prompts.remove(playerId, pending);
+            pending.cancel();
             return;
         }
 
         if (message != null && message.trim().equalsIgnoreCase("cancel")) {
             prompts.remove(playerId, pending);
+            pending.cancel();
             session.awaitingPrompt = false;
             session.status = "Prompt cancelled";
             render(session);
@@ -293,7 +368,23 @@ public final class BotManagementUI implements Listener {
             return;
         }
 
+        if (!player.hasPermission(requiredPermission(pending.action()))) {
+            prompts.remove(playerId, pending);
+            pending.cancel();
+            session.awaitingPrompt = false;
+            if (!player.hasPermission(MANAGE_PERMISSION)) {
+                player.sendMessage(ChatColor.RED + "You no longer have permission to use bot management.");
+                removeSession(playerId, false);
+                return;
+            }
+            session.status = "Permission recheck failed; nothing was dispatched.";
+            render(session);
+            reopen(session, player);
+            return;
+        }
+
         if (!prompts.remove(playerId, pending)) return;
+        pending.cancel();
         session.awaitingPrompt = false;
         String command = commandFor(pending.action(), message);
         if (pending.action().destructive()) {
@@ -309,6 +400,23 @@ public final class BotManagementUI implements Listener {
                 reopen(session, player);
             }
         }
+    }
+
+    private void expirePrompt(UUID playerId, PendingPrompt pending) {
+        if (!prompts.remove(playerId, pending)) return;
+        pending.cancel();
+        Session session = sessions.get(playerId);
+        if (session == null) return;
+        session.awaitingPrompt = false;
+        session.status = "Prompt expired";
+        Player player = Bukkit.getPlayer(playerId);
+        if (player == null) {
+            removeSession(playerId, false);
+            return;
+        }
+        player.sendMessage(ChatColor.YELLOW + "The input prompt expired. No action was run.");
+        render(session);
+        reopen(session, player);
     }
 
     private void requestConfirmation(Session session, UiAction action, String command) {
@@ -365,8 +473,7 @@ public final class BotManagementUI implements Listener {
         } catch (RuntimeException error) {
             accepted = false;
         }
-        String shown = command.length() > 48 ? command.substring(0, 45) + "..." : command;
-        session.status = (accepted ? "Ran /" : "Rejected /") + shown;
+        session.status = dispatchStatus(accepted, command);
         render(session);
     }
 
@@ -385,6 +492,11 @@ public final class BotManagementUI implements Listener {
             Player player = Bukkit.getPlayer(session.playerId);
             if (player == null) {
                 removeSession(session.playerId, false);
+                continue;
+            }
+            if (!player.hasPermission(MANAGE_PERMISSION)) {
+                player.sendMessage(ChatColor.RED + "You no longer have permission to use bot management.");
+                removeSession(session.playerId, true);
                 continue;
             }
             if (session.awaitingPrompt) continue;
@@ -420,12 +532,20 @@ public final class BotManagementUI implements Listener {
 
     private void removeSession(UUID playerId, boolean closeInventory) {
         Session removed = sessions.remove(playerId);
-        prompts.remove(playerId);
+        clearPrompt(playerId);
         if (removed == null) return;
 
+        removed.awaitingPrompt = false;
         lifecycle.sessionClosed();
         if (closeInventory) closeInventoryIfOwned(removed);
         if (!lifecycle.shouldRefresh()) stopRefreshTask();
+    }
+
+    private void clearPrompt(UUID playerId) {
+        PendingPrompt pending = prompts.remove(playerId);
+        if (pending != null) pending.cancel();
+        Session session = sessions.get(playerId);
+        if (session != null) session.awaitingPrompt = false;
     }
 
     private void closeSession(UUID playerId, boolean closeInventory) {
@@ -434,6 +554,10 @@ public final class BotManagementUI implements Listener {
 
     private void reopen(Session session, Player player) {
         if (shutdown || session == null || player == null || !player.isOnline()) return;
+        if (!player.hasPermission(MANAGE_PERMISSION)) {
+            removeSession(session.playerId, false);
+            return;
+        }
         player.openInventory(session.inventory);
         ensureRefreshTask();
     }
@@ -455,7 +579,9 @@ public final class BotManagementUI implements Listener {
     private void finishShutdown() {
         Collection<Session> active = new ArrayList<>(sessions.values());
         sessions.clear();
+        prompts.values().forEach(PendingPrompt::cancel);
         prompts.clear();
+        active.forEach(session -> session.awaitingPrompt = false);
         lifecycle.shutdown();
         stopRefreshTask();
         for (Session session : active) closeInventoryIfOwned(session);
@@ -518,11 +644,16 @@ public final class BotManagementUI implements Listener {
 
     private void renderBots(Session session) {
         List<Terminator> bots = currentBots();
-        int pageCount = pageCount(bots.size());
-        session.state.pageIndex = Math.min(session.state.pageIndex, pageCount - 1);
-        int start = session.state.pageIndex * BOT_PAGE_SIZE;
+        int pages = pageCount(bots.size());
+        int pageIndex = clampPageIndex(session.state.pageIndex(), pages);
+        session.state.setPageIndex(pageIndex, pages);
+        int start = pageIndex * BOT_PAGE_SIZE;
         int end = Math.min(start + BOT_PAGE_SIZE, bots.size());
         int slot = 10;
+        if (bots.isEmpty()) {
+            put(session, slot, Material.BARRIER, "No active bots", null, null,
+                    "Spawn a bot to make it appear here.");
+        }
         for (int index = start; index < end; index++) {
             Terminator bot = bots.get(index);
             UUID id = botId(bot);
@@ -535,7 +666,7 @@ public final class BotManagementUI implements Listener {
                             + ChatColor.GRAY + " | " + location,
                     "Click for status and actions");
         }
-        session.status = "Bots " + (bots.size()) + " | page " + (session.state.pageIndex + 1) + "/" + pageCount;
+        session.status = "Bots " + bots.size() + " | page " + (pageIndex + 1) + "/" + pages;
     }
 
     private void renderBotDetail(Session session) {
@@ -555,26 +686,35 @@ public final class BotManagementUI implements Listener {
                 "Health: " + bot.getBotHealth() + "/" + bot.getBotMaxHealth(),
                 "Alive: " + bot.isBotAlive(),
                 "World: " + world);
-        if (!isUniqueBotName(bot.getBotName(), currentBots().stream().map(Terminator::getBotName).toList())) {
+        boolean uniqueName = isUniqueBotName(bot.getBotName(), currentBots().stream()
+                .map(Terminator::getBotName).toList());
+        if (!uniqueName) {
             put(session, 12, Material.BARRIER, "Duplicate bot name", null, null,
-                    "Selected actions are disabled because commands target bots by name.",
-                    "Use a unique bot name to avoid affecting the wrong bot.");
-            return;
+                    "Name-based commands are disabled for this selection.",
+                    "The inventory editor still targets this exact bot UUID.");
         }
-        put(session, 11, Material.PAPER, "Bot info", UiAction.BOT_INFO, bot.getBotName(),
-                "/bot inspect info " + bot.getBotName());
-        put(session, 12, Material.REDSTONE, "AI info", UiAction.AI_INFO, bot.getBotName(),
-                "/ai inspect info " + bot.getBotName());
-        put(session, 13, Material.DIAMOND_SWORD, "Weapon status", UiAction.BOT_WEAPONS, bot.getBotName(),
-                "/bot inspect weapons " + bot.getBotName());
-        put(session, 14, Material.CHEST, "Edit inventory", UiAction.BOT_INVENTORY, bot.getBotName(),
-                "/bot equipment inventory " + bot.getBotName());
-        put(session, 15, Material.OBSERVER, "Combat debug on", UiAction.BOT_COMBAT_DEBUG,
-                bot.getBotName() + " on", "/bot debug combat " + bot.getBotName() + " on");
-        put(session, 16, Material.BARRIER, "Combat debug off", UiAction.BOT_COMBAT_DEBUG,
-                bot.getBotName() + " off", "/bot debug combat " + bot.getBotName() + " off");
-        put(session, 17, Material.SHULKER_BOX, "Apply loadout...", UiAction.BOT_LOADOUT, null,
-                "Enter loadout [bot-name]");
+        if (uniqueName) {
+            put(session, 11, Material.PAPER, "Bot info", UiAction.BOT_INFO, bot.getBotName(),
+                    "/bot inspect info " + bot.getBotName());
+            put(session, 12, Material.REDSTONE, "AI info", UiAction.AI_INFO, bot.getBotName(),
+                    "/ai inspect info " + bot.getBotName());
+            put(session, 13, Material.DIAMOND_SWORD, "Weapon status", UiAction.BOT_WEAPONS, bot.getBotName(),
+                    "/bot inspect weapons " + bot.getBotName());
+        }
+        UUID exactBotId = botId(bot);
+        if (exactBotId != null) {
+            put(session, 14, Material.CHEST, "Edit inventory: " + bot.getBotName(), UiAction.BOT_INVENTORY,
+                    exactBotId.toString(), "/bot equipment inventory <exact selected bot>",
+                    "UUID: " + exactBotId);
+        }
+        if (uniqueName) {
+            put(session, 15, Material.OBSERVER, "Combat debug on", UiAction.BOT_COMBAT_DEBUG,
+                    bot.getBotName() + " on", "/bot debug combat " + bot.getBotName() + " on");
+            put(session, 16, Material.BARRIER, "Combat debug off", UiAction.BOT_COMBAT_DEBUG,
+                    bot.getBotName() + " off", "/bot debug combat " + bot.getBotName() + " off");
+            put(session, 17, Material.SHULKER_BOX, "Apply loadout...", UiAction.BOT_LOADOUT, null,
+                    "Enter loadout [bot-name]");
+        }
     }
 
     private void renderCreate(Session session) {
@@ -594,26 +734,29 @@ public final class BotManagementUI implements Listener {
         boolean respawnEnabled = plugin != null && plugin.getManager() != null
                 && plugin.getManager().isRespawnEnabled();
         boolean movementV2Enabled = plugin != null && MovementV2Settings.isEnabled(plugin);
+        boolean admin = hasAdminPermission(session);
         put(session, 10, Material.ENDER_PEARL, "Gather all bots", UiAction.BOT_GATHER, null,
                 "Teleport living bots to you");
         put(session, 11, Material.COMPASS, "Circular scatter", UiAction.BOT_SCATTER, null,
                 "Use the default safe circular radius");
         put(session, 12, Material.SPYGLASS, "Scatter radius...", UiAction.BOT_SCATTER_RADIUS, null,
                 "Enter a radius; command validates it");
-        put(session, 13, Material.TOTEM_OF_UNDYING,
-                "Respawn: " + (respawnEnabled ? "enabled" : "disabled"), UiAction.BOT_RESPAWN, null,
-                "/bot settings auto-respawn");
-        put(session, 14, Material.LIME_DYE, "Enable respawn", UiAction.BOT_RESPAWN, "true",
-                "/bot settings auto-respawn true");
-        put(session, 15, Material.RED_DYE, "Disable respawn", UiAction.BOT_RESPAWN, "false",
-                "/bot settings auto-respawn false");
-        put(session, 16, Material.FEATHER,
-                "Movement V2: " + (movementV2Enabled ? "enabled" : "disabled"), UiAction.BOT_MOVEMENT_V2, "status",
-                "/bot settings movement-v2 status");
-        put(session, 17, Material.LIME_WOOL, "Enable Movement V2", UiAction.BOT_MOVEMENT_V2, "on",
-                "/bot settings movement-v2 on");
-        put(session, 18, Material.RED_WOOL, "Disable Movement V2", UiAction.BOT_MOVEMENT_V2, "off",
-                "/bot settings movement-v2 off");
+        if (admin) {
+            put(session, 13, Material.TOTEM_OF_UNDYING,
+                    "Respawn: " + (respawnEnabled ? "enabled" : "disabled"), UiAction.BOT_RESPAWN, null,
+                    "/bot settings auto-respawn");
+            put(session, 14, Material.LIME_DYE, "Enable respawn", UiAction.BOT_RESPAWN, "true",
+                    "/bot settings auto-respawn true");
+            put(session, 15, Material.RED_DYE, "Disable respawn", UiAction.BOT_RESPAWN, "false",
+                    "/bot settings auto-respawn false");
+            put(session, 16, Material.FEATHER,
+                    "Movement V2: " + (movementV2Enabled ? "enabled" : "disabled"), UiAction.BOT_MOVEMENT_V2, "status",
+                    "/bot settings movement-v2 status");
+            put(session, 17, Material.LIME_WOOL, "Enable Movement V2", UiAction.BOT_MOVEMENT_V2, "on",
+                    "/bot settings movement-v2 on");
+            put(session, 18, Material.RED_WOOL, "Disable Movement V2", UiAction.BOT_MOVEMENT_V2, "off",
+                    "/bot settings movement-v2 off");
+        }
     }
 
     private void renderAi(Session session) {
@@ -629,10 +772,18 @@ public final class BotManagementUI implements Listener {
                 "/ai brain load");
         if (session.selectedBot != null) {
             Terminator bot = findBot(session.selectedBot);
-            put(session, 15, Material.WRITABLE_BOOK, "Save selected brain", UiAction.AI_BRAIN_SAVE,
-                    bot == null ? null : bot.getBotName(), "/ai brain save <selected bot>");
-            put(session, 19, Material.REDSTONE, "AI info (selected)", UiAction.AI_INFO,
-                    bot == null ? null : bot.getBotName(), "/ai inspect info <selected bot>");
+            String name = bot == null ? null : bot.getBotName();
+            if (isUniqueBotName(name, currentBots().stream().map(Terminator::getBotName).toList())) {
+                put(session, 15, Material.WRITABLE_BOOK, "Save selected brain", UiAction.AI_BRAIN_SAVE,
+                        name, "/ai brain save <selected bot>");
+                put(session, 19, Material.REDSTONE, "AI info (selected)", UiAction.AI_INFO,
+                        name, "/ai inspect info <selected bot>");
+            } else {
+                put(session, 15, Material.GRAY_DYE, "Selected brain unavailable", null, null,
+                        "The selected bot name is ambiguous.");
+                put(session, 19, Material.GRAY_DYE, "Selected info unavailable", null, null,
+                        "The selected bot name is ambiguous.");
+            }
         } else {
             put(session, 15, Material.WRITABLE_BOOK, "Save brain...", UiAction.AI_BRAIN_SAVE_INPUT, null,
                     "Enter optional bot name");
@@ -652,8 +803,15 @@ public final class BotManagementUI implements Listener {
     private void renderCombat(Session session) {
         put(session, 10, Material.DIAMOND_SWORD, "Weapons (all)", UiAction.BOT_WEAPONS, null,
                 "/bot inspect weapons");
-        put(session, 11, Material.IRON_SWORD, "Weapons (selected)", UiAction.BOT_WEAPONS,
-                selectedName(session), "/bot inspect weapons <selected bot>");
+        String selectedName = selectedName(session);
+        boolean uniqueSelected = isUniqueBotName(selectedName,
+                currentBots().stream().map(Terminator::getBotName).toList());
+        put(session, 11, uniqueSelected ? Material.IRON_SWORD : Material.GRAY_DYE,
+                uniqueSelected ? "Weapons (selected)" : "Selected weapons unavailable",
+                uniqueSelected ? UiAction.BOT_WEAPONS : null,
+                uniqueSelected ? selectedName : null,
+                uniqueSelected ? "/bot inspect weapons <selected bot>"
+                        : "The selected bot name is ambiguous.");
         put(session, 12, Material.CHEST, "Give item...", UiAction.BOT_GIVE, null,
                 "item [bot-name] [slot]");
         put(session, 13, Material.BRICKS, "Placement material...", UiAction.BOT_PLACE, null,
@@ -670,19 +828,28 @@ public final class BotManagementUI implements Listener {
                 "preset-name bot-name");
         put(session, 19, Material.ENCHANTED_BOOK, "Apply preset...", UiAction.BOT_PRESET_APPLY, null,
                 "preset-name [bot-name]");
-        put(session, 20, Material.TNT, "Delete preset...", UiAction.BOT_PRESET_DELETE, null,
-                "Confirmation required");
-        String selectedName = selectedName(session);
-        put(session, 21, Material.CHEST, selectedName == null ? "Open inventory..." : "Open selected inventory",
-                selectedName == null ? UiAction.BOT_INVENTORY_INPUT : UiAction.BOT_INVENTORY,
-                selectedName, selectedName == null ? "Enter bot-name" : "/bot equipment inventory <selected bot>");
+        if (hasAdminPermission(session)) {
+            put(session, 20, Material.TNT, "Delete preset...", UiAction.BOT_PRESET_DELETE, null,
+                    "Confirmation required");
+        }
+        if (session.selectedBot != null && selectedName == null) {
+            put(session, 21, Material.GRAY_DYE, "Selected inventory unavailable", null, null,
+                    "The selected bot is no longer active.");
+        } else {
+            put(session, 21, Material.CHEST, selectedName == null ? "Open inventory..." : "Open selected inventory",
+                    selectedName == null ? UiAction.BOT_INVENTORY_INPUT : UiAction.BOT_INVENTORY,
+                    selectedName, selectedName == null ? "Enter bot-name" : "/bot equipment inventory <selected bot>");
+        }
         put(session, 22, Material.PAPER, "Count bots", UiAction.BOT_COUNT, null,
                 "/bot inspect list");
     }
 
     private void renderAdmin(Session session) {
-        put(session, 10, Material.TNT, "Reset all bots", UiAction.BOT_RESET, null,
-                "Confirmation and permission recheck required");
+        boolean admin = hasAdminPermission(session);
+        if (admin) {
+            put(session, 10, Material.TNT, "Reset all bots", UiAction.BOT_RESET, null,
+                    "Confirmation and permission recheck required");
+        }
         put(session, 11, Material.LIME_DYE, "Mob targeting on", UiAction.BOT_SETTINGS, "mobtarget true",
                 "/bot settings target-mobs true");
         put(session, 12, Material.RED_DYE, "Mob targeting off", UiAction.BOT_SETTINGS, "mobtarget false",
@@ -697,14 +864,16 @@ public final class BotManagementUI implements Listener {
                 "target-region bounds and weights");
         put(session, 17, Material.BARRIER, "Clear region", UiAction.BOT_SETTINGS_REGION_CLEAR, null,
                 "Confirmation required");
-        put(session, 18, Material.COMPARATOR, "Debug expression...", UiAction.BOT_DEBUG, null,
-                "Enter a behavior expression");
-        put(session, 19, Material.OBSERVER, "Combat debug all on", UiAction.BOT_COMBAT_DEBUG, "all on",
-                "/bot debug combat all on");
-        put(session, 20, Material.REDSTONE_TORCH, "Combat debug all off", UiAction.BOT_COMBAT_DEBUG, "all off",
-                "/bot debug combat all off");
-        put(session, 21, Material.PAPER, "Combat debug args...", UiAction.BOT_COMBAT_DEBUG_INPUT, null,
-                "bot-name|all on|off");
+        if (admin) {
+            put(session, 18, Material.COMPARATOR, "Debug expression...", UiAction.BOT_DEBUG, null,
+                    "Enter a behavior expression");
+            put(session, 19, Material.OBSERVER, "Combat debug all on", UiAction.BOT_COMBAT_DEBUG, "all on",
+                    "/bot debug combat all on");
+            put(session, 20, Material.REDSTONE_TORCH, "Combat debug all off", UiAction.BOT_COMBAT_DEBUG, "all off",
+                    "/bot debug combat all off");
+            put(session, 21, Material.PAPER, "Combat debug args...", UiAction.BOT_COMBAT_DEBUG_INPUT, null,
+                    "bot-name|all on|off");
+        }
     }
 
     private void renderEnvironment(Session session) {
@@ -734,8 +903,10 @@ public final class BotManagementUI implements Listener {
                 "Confirmation required");
         put(session, 22, Material.COMPARATOR, "Mob list type...", UiAction.ENV_MOB_LIST_TYPE, null,
                 "custom list mode");
-        put(session, 23, Material.FEATHER, "Movement V2 status", UiAction.ENV_MOVEMENT_V2_STATUS, null,
-                "/bot debug movement [bot-name]");
+        if (hasAdminPermission(session)) {
+            put(session, 23, Material.FEATHER, "Movement V2 status", UiAction.ENV_MOVEMENT_V2_STATUS, null,
+                    "/bot debug movement [bot-name]");
+        }
     }
 
     private void renderHelp(Session session) {
@@ -768,10 +939,15 @@ public final class BotManagementUI implements Listener {
         }
         if (session.state.page == Page.BOTS) {
             int pages = pageCount(currentBots().size());
-            if (session.state.pageIndex + 1 < pages) {
-                put(session, 51, Material.SPECTRAL_ARROW, "Next page", UiAction.NEXT_PAGE, null,
-                        "Page " + (session.state.pageIndex + 2) + "/" + pages);
-            }
+            int pageIndex = clampPageIndex(session.state.pageIndex(), pages);
+            put(session, 47, pageIndex > 0 ? Material.ARROW : Material.GRAY_DYE,
+                    "Previous page", UiAction.PREVIOUS_PAGE, null,
+                    pageIndex > 0 ? "Page " + pageIndex + "/" + pages : "Already on the first page");
+            put(session, 50, Material.PAPER, "Page " + (pageIndex + 1) + "/" + pages, null, null,
+                    currentBots().isEmpty() ? "No active bots" : "Select a bot above");
+            put(session, 51, pageIndex + 1 < pages ? Material.SPECTRAL_ARROW : Material.GRAY_DYE,
+                    "Next page", UiAction.NEXT_PAGE, null,
+                    pageIndex + 1 < pages ? "Page " + (pageIndex + 2) + "/" + pages : "Already on the last page");
         }
         put(session, 49, Material.PAPER, "Status", null, null, session.status);
         put(session, 53, Material.BARRIER, "Close", UiAction.CLOSE, null);
@@ -838,8 +1014,26 @@ public final class BotManagementUI implements Listener {
         return action != null && action.destructive();
     }
 
+    static boolean visibleForPermission(UiAction action, boolean admin) {
+        return action != null && (!action.requiresAdmin() || admin);
+    }
+
+    static String dispatchStatus(boolean accepted, String command) {
+        String value = command == null ? "" : command;
+        String shown = value.length() > 48 ? value.substring(0, 45) + "..." : value;
+        return (accepted ? "Dispatched /" : "Rejected /") + shown;
+    }
+
     static long refreshIntervalTicks() {
         return REFRESH_INTERVAL_TICKS;
+    }
+
+    static long promptTimeoutTicks() {
+        return PROMPT_TIMEOUT_TICKS;
+    }
+
+    static boolean isCurrentPrompt(PendingPrompt active, PendingPrompt candidate) {
+        return active != null && active == candidate && !candidate.cancelled();
     }
 
     static Page initialPage() {
@@ -908,8 +1102,18 @@ public final class BotManagementUI implements Listener {
         return bot == null || bot.getBukkitEntity() == null ? null : bot.getBukkitEntity().getUniqueId();
     }
 
-    private static int pageCount(int count) {
+    static int pageCount(int count) {
         return Math.max(1, (count + BOT_PAGE_SIZE - 1) / BOT_PAGE_SIZE);
+    }
+
+    static int clampPageIndex(int index, int pages) {
+        int last = Math.max(0, pages - 1);
+        return Math.max(0, Math.min(index, last));
+    }
+
+    private boolean hasAdminPermission(Session session) {
+        Player player = Bukkit.getPlayer(session.playerId);
+        return player != null && player.hasPermission(ADMIN_PERMISSION);
     }
 
     private String selectedName(Session session) {
@@ -941,6 +1145,7 @@ public final class BotManagementUI implements Listener {
         OPEN_ENVIRONMENT(null, false, false, false, "Environment"),
         OPEN_HELP(null, false, false, false, "Help and plugin info"),
         BACK(null, false, false, false, "Back"),
+        PREVIOUS_PAGE(null, false, false, false, "Previous page"),
         NEXT_PAGE(null, false, false, false, "Next page"),
         CLOSE(null, false, false, false, "Close"),
         SELECT_BOT(null, false, false, false, "Select bot"),
@@ -1073,6 +1278,10 @@ public final class BotManagementUI implements Listener {
             pageIndex = 0;
         }
 
+        void setPageIndex(int index, int pages) {
+            pageIndex = clampPageIndex(index, pages);
+        }
+
         Page page() {
             return page;
         }
@@ -1118,7 +1327,34 @@ public final class BotManagementUI implements Listener {
     private record Button(UiAction action, String payload) {
     }
 
-    private record PendingPrompt(UiAction action, String hint) {
+    static final class PendingPrompt {
+        private final UiAction action;
+        private final String hint;
+        private BukkitTask timeoutTask;
+        private boolean cancelled;
+
+        PendingPrompt(UiAction action, String hint) {
+            this.action = action;
+            this.hint = hint;
+        }
+
+        UiAction action() {
+            return action;
+        }
+
+        String hint() {
+            return hint;
+        }
+
+        void cancel() {
+            if (timeoutTask != null && !timeoutTask.isCancelled()) timeoutTask.cancel();
+            timeoutTask = null;
+            cancelled = true;
+        }
+
+        boolean cancelled() {
+            return cancelled;
+        }
     }
 
     private record Confirmation(UiAction action, String command, Page returnPage) {

--- a/TerminatorPlus-Plugin/src/main/java/net/nuggetmc/tplus/bot/loadout/BotInventory.java
+++ b/TerminatorPlus-Plugin/src/main/java/net/nuggetmc/tplus/bot/loadout/BotInventory.java
@@ -632,7 +632,7 @@ public final class BotInventory {
     }
 
     // -------------------------------------------------------------------------
-    // Inventory copy (used to propagate GUI edits to all same-name bots)
+    // Explicit inventory copy utility for callers that intentionally clone a kit.
     // -------------------------------------------------------------------------
 
     /**
@@ -668,7 +668,9 @@ public final class BotInventory {
      * armor, offhand) and reorganises them into the best combat configuration:
      * best armor → armor slots, weapons/tools → hotbar (by priority), leftover → storage.
      *
-     * Called automatically when the inventory GUI closes.
+     * Called explicitly when a user opts into auto-equip while saving an
+     * inventory edit, or by command/loadout code that needs the deterministic
+     * combat layout.
      */
     public void autoEquip() {
         PlayerInventory inv = raw();

--- a/TerminatorPlus-Plugin/src/main/java/net/nuggetmc/tplus/command/commands/BotCommand.java
+++ b/TerminatorPlus-Plugin/src/main/java/net/nuggetmc/tplus/command/commands/BotCommand.java
@@ -8,7 +8,6 @@ import net.nuggetmc.tplus.api.agent.legacyagent.LegacyMats;
 import net.nuggetmc.tplus.api.utils.ChatUtils;
 import net.nuggetmc.tplus.bot.Bot;
 import net.nuggetmc.tplus.bot.BotManagerImpl;
-import net.nuggetmc.tplus.bot.gui.BotInventoryGUI;
 import net.nuggetmc.tplus.bot.loadout.BotInventory;
 import net.nuggetmc.tplus.bot.navigation.MovementV2Settings;
 import net.nuggetmc.tplus.bot.preset.BotPreset;
@@ -1378,12 +1377,25 @@ public class BotCommand extends CommandInstance {
             sender.sendMessage(ChatColor.RED + "This command can only be run by a player.");
             return;
         }
-        Bot bot = findBot(name, player.getLocation());
-        if (bot == null) {
+        List<Bot> matches = manager.fetch().stream()
+                .filter(t -> t instanceof Bot)
+                .map(t -> (Bot) t)
+                .filter(bot -> name.equalsIgnoreCase(bot.getBotName()))
+                .toList();
+        if (matches.isEmpty()) {
             sender.sendMessage("Could not find bot " + ChatColor.GREEN + name + ChatColor.RESET + "!");
             return;
         }
-        new BotInventoryGUI(bot).open(player);
+        if (matches.size() > 1) {
+            sender.sendMessage(ChatColor.RED + "Inventory editing is ambiguous: multiple bots use the name "
+                    + ChatColor.YELLOW + name + ChatColor.RED + ". Select the exact bot in /bot first.");
+            return;
+        }
+        if (plugin.getInventoryListener() == null) {
+            sender.sendMessage(ChatColor.RED + "The bot inventory editor is unavailable right now.");
+            return;
+        }
+        plugin.getInventoryListener().open(player, matches.get(0));
     }
 
     public List<String> inventoryAutofill(CommandSender sender, String[] args) {

--- a/TerminatorPlus-Plugin/src/test/java/net/nuggetmc/tplus/bot/gui/BotInventoryGUITest.java
+++ b/TerminatorPlus-Plugin/src/test/java/net/nuggetmc/tplus/bot/gui/BotInventoryGUITest.java
@@ -1,0 +1,101 @@
+package net.nuggetmc.tplus.bot.gui;
+
+import org.bukkit.Material;
+import org.bukkit.event.inventory.ClickType;
+import org.junit.jupiter.api.Test;
+
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class BotInventoryGUITest {
+
+    @Test
+    void slotMapHasStableEditableControlAndFillerRegions() {
+        assertTrue(BotInventoryGUI.isEditableSlot(0));
+        assertTrue(BotInventoryGUI.isEditableSlot(40));
+        assertFalse(BotInventoryGUI.isEditableSlot(41));
+        assertTrue(BotInventoryGUI.isArmorOrOffhand(36));
+        assertTrue(BotInventoryGUI.isArmorOrOffhand(40));
+        assertFalse(BotInventoryGUI.isArmorOrOffhand(35));
+        assertFalse(BotInventoryGUI.isFillerSlot(BotInventoryGUI.SAVE_SLOT));
+        assertTrue(BotInventoryGUI.isFillerSlot(46));
+        assertEquals(BotInventoryGUI.Control.AUTO_EQUIP,
+                BotInventoryGUI.actionForSlot(BotInventoryGUI.AUTO_EQUIP_SLOT));
+        assertEquals(BotInventoryGUI.Control.SAVE,
+                BotInventoryGUI.actionForSlot(BotInventoryGUI.SAVE_SLOT));
+        assertEquals(BotInventoryGUI.Control.DISCARD,
+                BotInventoryGUI.actionForSlot(BotInventoryGUI.DISCARD_SLOT));
+        assertEquals(BotInventoryGUI.Control.CLOSE,
+                BotInventoryGUI.actionForSlot(BotInventoryGUI.CLOSE_SLOT));
+        assertNull(BotInventoryGUI.actionForSlot(BotInventoryGUI.STATUS_SLOT));
+    }
+
+    @Test
+    void equipmentValidationMatchesCanonicalSlots() {
+        assertTrue(BotInventoryGUI.isValidMaterialForSlot(36, Material.DIAMOND_BOOTS));
+        assertFalse(BotInventoryGUI.isValidMaterialForSlot(36, Material.DIAMOND_HELMET));
+        assertTrue(BotInventoryGUI.isValidMaterialForSlot(37, Material.IRON_LEGGINGS));
+        assertFalse(BotInventoryGUI.isValidMaterialForSlot(37, Material.IRON_BOOTS));
+        assertTrue(BotInventoryGUI.isValidMaterialForSlot(38, Material.ELYTRA));
+        assertTrue(BotInventoryGUI.isValidMaterialForSlot(39, Material.CARVED_PUMPKIN));
+        assertFalse(BotInventoryGUI.isValidMaterialForSlot(39, Material.SHIELD));
+        assertTrue(BotInventoryGUI.isValidMaterialForSlot(40, Material.SHIELD));
+
+        assertTrue(BotInventoryGUI.validationError(new org.bukkit.inventory.ItemStack[36])
+                .contains("incomplete"));
+        org.bukkit.inventory.ItemStack[] contents = new org.bukkit.inventory.ItemStack[BotInventoryGUI.EDITABLE_SLOTS];
+        contents[36] = null;
+        assertNull(BotInventoryGUI.validationError(contents));
+        contents[36] = null;
+        assertNull(BotInventoryGUI.validationError(contents));
+    }
+
+    @Test
+    void editStateTracksTheOriginalSnapshotAndSelectedSlot() {
+        org.bukkit.inventory.ItemStack[] original = new org.bukkit.inventory.ItemStack[BotInventoryGUI.EDITABLE_SLOTS];
+        BotInventoryGUI.EditState state = new BotInventoryGUI.EditState(original, 4);
+        org.bukkit.inventory.ItemStack[] changed = new org.bukkit.inventory.ItemStack[BotInventoryGUI.EDITABLE_SLOTS];
+        assertFalse(state.changed(changed));
+        assertEquals(4, state.selectedHotbarSlot());
+    }
+
+    @Test
+    void prohibitedShortcutsAndTransfersAreBlocked() {
+        assertFalse(BotInventoryListener.isProhibitedClick(ClickType.LEFT));
+        assertFalse(BotInventoryListener.isProhibitedClick(ClickType.RIGHT));
+        for (ClickType click : new ClickType[]{ClickType.SHIFT_LEFT, ClickType.NUMBER_KEY,
+                ClickType.DOUBLE_CLICK, ClickType.SWAP_OFFHAND, ClickType.MIDDLE}) {
+            assertTrue(BotInventoryListener.isProhibitedClick(click), click.name());
+        }
+    }
+
+    @Test
+    void editorLocksAllowOneExactBotAndViewerAndReleaseCleanly() {
+        BotInventoryListener.EditorLocks locks = new BotInventoryListener.EditorLocks();
+        UUID bot = UUID.randomUUID();
+        UUID viewer = UUID.randomUUID();
+        UUID otherViewer = UUID.randomUUID();
+        UUID otherBot = UUID.randomUUID();
+
+        assertTrue(locks.tryAcquire(bot, viewer));
+        assertFalse(locks.tryAcquire(bot, otherViewer));
+        assertFalse(locks.tryAcquire(otherBot, viewer));
+        assertTrue(locks.owns(bot, viewer));
+        assertTrue(locks.locked(bot));
+        assertEquals(1, locks.size());
+
+        locks.release(bot, otherViewer);
+        assertEquals(1, locks.size());
+        locks.release(bot, viewer);
+        assertEquals(0, locks.size());
+        assertFalse(locks.locked(bot));
+
+        assertTrue(locks.tryAcquire(bot, otherViewer));
+        locks.clear();
+        assertEquals(0, locks.size());
+    }
+}

--- a/TerminatorPlus-Plugin/src/test/java/net/nuggetmc/tplus/bot/gui/BotManagementUITest.java
+++ b/TerminatorPlus-Plugin/src/test/java/net/nuggetmc/tplus/bot/gui/BotManagementUITest.java
@@ -35,6 +35,24 @@ class BotManagementUITest {
     }
 
     @Test
+    void botPagesClampAtBothBoundariesIncludingEmptyLists() {
+        assertEquals(1, BotManagementUI.pageCount(0));
+        assertEquals(1, BotManagementUI.pageCount(1));
+        assertEquals(2, BotManagementUI.pageCount(BotManagementUI.BOT_PAGE_SIZE + 1));
+        assertEquals(0, BotManagementUI.clampPageIndex(-1, 1));
+        assertEquals(0, BotManagementUI.clampPageIndex(99, 1));
+        assertEquals(1, BotManagementUI.clampPageIndex(1, 2));
+        assertEquals(1, BotManagementUI.clampPageIndex(99, 2));
+
+        BotManagementUI.PageState state = new BotManagementUI.PageState();
+        state.navigate(BotManagementUI.Page.BOTS);
+        state.setPageIndex(99, 2);
+        assertEquals(1, state.pageIndex());
+        state.setPageIndex(-1, 2);
+        assertEquals(0, state.pageIndex());
+    }
+
+    @Test
     void commandMappingUsesExistingPlayerCommands() {
         assertEquals("bot spawn single", BotManagementUI.commandFor(BotManagementUI.UiAction.BOT_CREATE));
         assertEquals("bot spawn multiple 3 bot", BotManagementUI.commandFor(
@@ -55,6 +73,23 @@ class BotManagementUITest {
         assertTrue(BotManagementUI.requiresConfirmation(BotManagementUI.UiAction.BOT_PRESET_DELETE));
         assertFalse(BotManagementUI.requiresConfirmation(BotManagementUI.UiAction.BOT_GATHER));
         assertTrue(BotManagementUI.UiAction.BOT_RESET.requiresAdmin());
+    }
+
+    @Test
+    void adminOnlyActionsAreHiddenWithoutAdminPermission() {
+        assertTrue(BotManagementUI.visibleForPermission(BotManagementUI.UiAction.BOT_RESET, true));
+        assertFalse(BotManagementUI.visibleForPermission(BotManagementUI.UiAction.BOT_RESET, false));
+        assertTrue(BotManagementUI.visibleForPermission(BotManagementUI.UiAction.BOT_GATHER, false));
+    }
+
+    @Test
+    void dispatchFeedbackDistinguishesAcceptedFromRejectedCommands() {
+        assertEquals("Dispatched /bot move gather",
+                BotManagementUI.dispatchStatus(true, "bot move gather"));
+        assertEquals("Rejected /bot move gather",
+                BotManagementUI.dispatchStatus(false, "bot move gather"));
+        assertTrue(BotManagementUI.dispatchStatus(true, "abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyz")
+                .endsWith("..."));
     }
 
     @Test
@@ -108,5 +143,22 @@ class BotManagementUITest {
         assertTrue(BotManagementUI.isSafePromptInput("12 bot-name 1 2 3"));
         assertFalse(BotManagementUI.isSafePromptInput("bot\nreset"));
         assertFalse(BotManagementUI.isSafePromptInput("x\u0000y"));
+    }
+
+    @Test
+    void promptsHaveARealTimeoutAndCancellationIsObservable() {
+        assertEquals(1200L, BotManagementUI.promptTimeoutTicks());
+        BotManagementUI.PendingPrompt pending = new BotManagementUI.PendingPrompt(
+                BotManagementUI.UiAction.BOT_CREATE, "name");
+        BotManagementUI.PendingPrompt replacement = new BotManagementUI.PendingPrompt(
+                BotManagementUI.UiAction.BOT_MULTI, "amount name");
+        assertEquals(BotManagementUI.UiAction.BOT_CREATE, pending.action());
+        assertEquals("name", pending.hint());
+        assertTrue(BotManagementUI.isCurrentPrompt(pending, pending));
+        assertFalse(BotManagementUI.isCurrentPrompt(replacement, pending));
+        assertFalse(pending.cancelled());
+        pending.cancel();
+        assertTrue(pending.cancelled());
+        assertFalse(BotManagementUI.isCurrentPrompt(pending, pending));
     }
 }

--- a/buildSrc/src/main/kotlin/net.nuggetmc.java-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/net.nuggetmc.java-conventions.gradle.kts
@@ -3,4 +3,4 @@ plugins {
 }
 
 group = "net.nuggetmc"
-version = "6.2.2-BETA-mc26.2"
+version = "6.2.3-BETA-mc26.2"

--- a/docs/how-terminatorplus-works/10-inventory-loadout-preset-gui-flow.md
+++ b/docs/how-terminatorplus-works/10-inventory-loadout-preset-gui-flow.md
@@ -129,19 +129,21 @@ templates. They can mutate broader runtime behavior when applied.
 
 `BotInventoryGUI.java` creates a chest-style GUI for editing bot inventory.
 
-`BotInventoryListener.java` handles inventory click/close events and syncs GUI
-state back to the bot on close.
+`BotInventoryListener.java` handles inventory click, drag, transfer, close, and
+lifecycle events. It keeps edits in a working copy and writes them back only
+when the user clicks the explicit Save control.
 
 The GUI sync flow is roughly:
 
 1. player opens bot inventory GUI
 2. filler slots and mirrored slots are displayed
 3. player edits inventory view
-4. on close, GUI contents are translated back into bot inventory state
-5. main inventory is pushed through NMS-backed snapshot application
-6. armor/offhand are applied through equipment-aware methods
-7. `autoEquip()` and loadout-state markers are updated
-8. matching same-name bots may also receive the synced inventory
+4. normal left/right clicks edit the working copy; bypass shortcuts are cancelled
+5. Save validates and translates the exact 41-slot snapshot into bot inventory state
+6. main inventory is pushed through NMS-backed snapshot application
+7. armor/offhand are applied through equipment-aware methods
+8. optional auto-equip and loadout-state markers are updated only on Save
+9. close, disconnect, removal, permission loss, or shutdown discards unsaved edits
 
 This is much more than a cosmetic editor. It is a real state mutation path into
 high-risk inventory code.

--- a/docs/how-terminatorplus-works/11-command-map.md
+++ b/docs/how-terminatorplus-works/11-command-map.md
@@ -44,33 +44,33 @@ the desired future default user path.
 | Command | Class/method | Purpose | Runtime state changed? | Current/legacy/archive status |
 |---|---|---|---|---|
 | `/bot` | `BotCommand.root(...)` | Main bot command entry and help surface | No | Active shell; docs should be narrowed |
-| `/bot create` | `BotCommand.create(...)` | Spawn a bot at/near a location with naming/skin options | Yes | Active/current 1v1 path |
-| `/bot multi` | `BotCommand.multi(...)` | Spawn multiple bots quickly | Yes | Active but broad-plugin behavior; strategy mismatch |
-| `/bot reset` | `BotCommand.reset(...)` | Remove/reset bots and AI state | Yes | Active admin/runtime control |
-| `/bot give` | `BotCommand.give(...)` | Give items to bot inventory/mainhand path | Yes | Active but high-risk inventory mutation |
-| `/bot place` | `BotCommand.place(...)` | Set the global block used by generic bot building and clutch placement; defaults to `COBBLESTONE` | Yes | Active legacy compatibility control |
-| `/bot armor` | `BotCommand.armor(...)` | Set armor/offhand equipment | Yes | Active but high-risk inventory mutation |
-| `/bot info` | `BotCommand.info(...)` | Show bot info; partial UX and placeholder behavior remain | No | Active but partially incomplete |
-| `/bot count` | `BotCommand.count(...)` | Show bot count | No | Active inspection utility |
+| `/bot spawn single` (legacy `/bot create`) | `BotCommand.spawn(...)` | Spawn a bot at/near a location with naming/skin options | Yes | Active/current 1v1 path |
+| `/bot spawn multiple` (legacy `/bot multi`) | `BotCommand.spawn(...)` | Spawn multiple bots quickly | Yes | Active but broad-plugin behavior; strategy mismatch |
+| `/bot admin reset` (legacy `/bot reset`) | `BotCommand.admin(...)` | Remove/reset bots and AI state | Yes | Active admin/runtime control |
+| `/bot equipment give` (legacy `/bot give`) | `BotCommand.equipment(...)` | Give items to bot inventory/mainhand path | Yes | Active but high-risk inventory mutation |
+| `/bot settings placement-material` (legacy `/bot place`) | `BotCommand.settings(...)` | Set the global block used by generic bot building and clutch placement; defaults to `COBBLESTONE` | Yes | Active legacy compatibility control |
+| `/bot equipment armor` (legacy `/bot armor`) | `BotCommand.equipment(...)` | Set armor/offhand equipment | Yes | Active but high-risk inventory mutation |
+| `/bot inspect info` (legacy `/bot info`) | `BotCommand.inspect(...)` | Show bot info; partial UX and placeholder behavior remain | No | Active but partially incomplete |
+| `/bot inspect list` (legacy `/bot count`) | `BotCommand.inspect(...)` | Show bot count | No | Active inspection utility |
 | `/bot settings` | `BotCommand.settings(...)` | Change target goals, region, and related globals | Yes | Active but legacy/protected runtime control |
-| `/bot debug` | `BotCommand.debug(...)` | Hidden reflective debugger/admin surface | Yes | Optional/debug/admin; risky |
-| `/bot weapons` | `BotCommand.weapons(...)` | Show weapon/loadout-related information | No | Active reference/inspection |
-| `/bot combatdebug` | `BotCommand.combatDebug(...)` | Toggle combat logging/tracing for bots | Yes | Optional/debug/admin |
-| `/bot gather` | `BotCommand.gather(...)` | Pull/gather bots around a player | Yes | Active but broad-plugin/admin behavior |
-| `/bot inventory` | `BotCommand.inventory(...)` | Open and sync inventory GUI editor | Yes | Active but high-risk |
+| `/bot debug behavior` (legacy `/bot debug`) | `BotCommand.debug(...)` | Hidden reflective debugger/admin surface | Yes | Optional/debug/admin; risky |
+| `/bot inspect weapons` (legacy `/bot weapons`) | `BotCommand.inspect(...)` | Show weapon/loadout-related information | No | Active reference/inspection |
+| `/bot debug combat` (legacy `/bot combatdebug`) | `BotCommand.debug(...)` | Toggle combat logging/tracing for bots | Yes | Optional/debug/admin |
+| `/bot move gather` (legacy `/bot gather`) | `BotCommand.move(...)` | Pull/gather bots around a player | Yes | Active but broad-plugin/admin behavior |
+| `/bot equipment inventory` (legacy `/bot inventory`) | `BotCommand.equipment(...)` | Open the exact-target transactional inventory editor | Yes | Active but high-risk |
 | `/bot preset save/apply/delete` | `BotCommand.preset(...)` | Persist or apply full presets | Yes | Active/current support system |
-| `/bot loadout` | `BotCommand.loadout(...)` | Apply structured loadouts | Yes | Active, but broader than narrow duel-core default |
-| `/bot loadoutmix` | `BotCommand.loadoutMix(...)` | Apply mixed or grouped loadout scenarios | Yes | Active training/broad-surface feature |
+| `/bot equipment loadout` (legacy `/bot loadout`) | `BotCommand.equipment(...)` | Apply structured loadouts | Yes | Active, but broader than narrow duel-core default |
+| `/bot equipment mixed-loadout` (legacy `/bot loadoutmix`) | `BotCommand.equipment(...)` | Apply mixed or grouped loadout scenarios | Yes | Active training/broad-surface feature |
 | `/ai` | `AICommand.root(...)` | Main AI command entry/help surface | No | Active shell |
-| `/ai reinforcement` | `AICommand.reinforcement(...)` | Start reinforcement/training flows; defaults toward movement-controller work | Yes | Active training-only |
+| `/ai train reinforcement` (legacy `/ai reinforcement`) | `AICommand.train(...)` | Start reinforcement/training flows; defaults toward movement-controller work | Yes | Active training-only |
 | `/ai reinforcement legacy` | `AICommand.reinforcement(...)` legacy mode branch | Start older legacy/full-NN training path | Yes | Legacy/protected training surface |
-| `/ai movement` | `AICommand.movement(...)` | Manage movement-controller runtime/training operations | Yes | Active training/runtime support |
+| `/ai spawn movement` (legacy `/ai movement`) | `AICommand.spawn(...)` | Spawn movement-controller bots | Yes | Active training/runtime support |
 | `/ai brain` | `AICommand.brain(...)` | Save/load/reset movement brains | Yes | Active persistence/training support |
 | `/ai evaluate` | `AICommand.evaluate(...)` | Export evaluation results/reports | Yes | Active training/debug surface |
-| `/ai random` | `AICommand.random(...)` | Use older random/full-NN style path | Yes | Legacy/reference |
-| `/ai stop` | `AICommand.stop(...)` | Stop AI/training sessions | Yes | Active runtime/training control |
-| `/ai info` | `AICommand.info(...)` | Show AI mode/status information | No | Active inspection utility |
-| `/botenvironment` | `BotEnvironmentCommand.*` | Adjust solid-material overrides and custom mob-list behavior | Yes | Active but legacy/protected admin tooling |
+| `/ai spawn random` (legacy `/ai random`) | `AICommand.spawn(...)` | Use older random/full-NN style path | Yes | Legacy/reference |
+| `/ai train stop` (legacy `/ai stop`) | `AICommand.train(...)` | Stop AI/training sessions | Yes | Active runtime/training control |
+| `/ai inspect info` (legacy `/ai info`) | `AICommand.inspect(...)` | Show AI mode/status information | No | Active inspection utility |
+| `/bot environment` (legacy `/botenvironment`) | `BotCommand.environment(...)` | Adjust solid-material overrides and custom mob-list behavior | Yes | Active but legacy/protected admin tooling |
 | `/terminatorplus` | `MainCommand.root(...)` | Plugin info/help surface | No | Active shell |
 | `/terminatorplus debuginfo` | `MainCommand.debugInfo(...)` | Upload debug info externally through `mclo.gs` | Yes | Optional/debug/admin with external side effect |
 

--- a/docs/how-terminatorplus-works/14-active-vs-legacy-vs-unused-matrix.md
+++ b/docs/how-terminatorplus-works/14-active-vs-legacy-vs-unused-matrix.md
@@ -47,7 +47,7 @@ This matrix classifies major systems using the following buckets:
 | `BotInventory.java` | Do not touch without runtime tests | NMS direct-write path for fake-player inventory | Inventory state, equip logic, hotbar state | Protect |
 | `PresetManager.java` | Active/current 1v1 path | `/bot preset` persistence and apply | Saves and applies presets | Keep |
 | `BotInventoryGUI.java` | Active/current 1v1 path | Opened by command and synced through listener | Inventory editing GUI | Keep |
-| `BotInventoryListener.java` | Active/current 1v1 path | Syncs GUI edits back to bots | GUI close/apply propagation | Keep |
+| `BotInventoryListener.java` | Active/current 1v1 path | Applies explicit saves and discards every other close path | Editor locks, validation, and lifecycle cleanup | Keep |
 | `BotCommand.java` | Active/current 1v1 path + archive candidate from default strategy | Registered command root with wide surface | Main player/admin bot command set | Reclassify docs first |
 | `AICommand.java` | Training-only | Exposes movement brain, reinforcement, evaluation flows | AI/training/admin surface | Keep; document as training |
 | `BotEnvironmentCommand.java` | Active but legacy/protected | Registered and mutates `LegacyMats`/custom mob list | Environment override/admin tooling | Keep but archive from default user path |

--- a/wiki/Commands.md
+++ b/wiki/Commands.md
@@ -47,7 +47,9 @@ Remove every spawned bot. **Requires** `terminatorplus.admin`.
 ## Equipment
 
 ### `/bot equipment inventory <bot-name>` (legacy `/bot inventory`, alias `inv`)
-Open a 54-slot chest GUI that mirrors the bot's inventory. Edits save on close. See [Inventory GUI](Inventory-GUI).
+Open a 54-slot chest GUI that edits one exact bot. Click **Save changes** to
+apply; closing discards unsaved edits. Ambiguous duplicate names are rejected.
+See [Inventory GUI](Inventory-GUI).
 
 ### `/bot equipment give <item> [bot-name] [slot]`
 - One arg: sets the default item for every bot.

--- a/wiki/Inventory-GUI.md
+++ b/wiki/Inventory-GUI.md
@@ -3,66 +3,83 @@
 > See [Legacy Status](Legacy-Status) for this page's reference status and
 > [Current Strategy](Current-Strategy) for the current target.
 
-
-Open any bot's inventory as a double-chest GUI:
+Open one exact bot's inventory as a double-chest GUI:
 
 ```
-/bot inventory <bot-name>
+/bot equipment inventory <bot-name>
 ```
 
-Alias: `/bot inv <bot-name>`.
+Legacy path and alias: `/bot inventory <bot-name>` and `/bot inv <bot-name>`.
+If more than one active bot has that name, the command refuses to guess. Select
+the bot from the `/bot` management menu and use its exact-identity inventory
+button instead.
 
 ## Slot map
 
-The top 5 rows (45 slots) mirror the bot's real inventory. The bottom row (9 slots) is locked — it's reserved decoration.
+The first 41 slots are a working copy of the bot's inventory. Equipment uses a
+stable, explicit mapping; the remaining slots are controls or locked decoration.
 
 ```
-Row 1 (slots  0 .. 8): Hotbar (slot 0 = selected-hotbar slot index)
-Row 2 (slots  9 ..17): Storage row 1
-Row 3 (slots 18 ..26): Storage row 2
-Row 4 (slots 27 ..35): Storage row 3
-Row 5 (slots 36 ..44): Armor + offhand
+Row 1 (slots  0 ..  8): hotbar (slot 0 = selected-hotbar slot index)
+Row 2 (slots  9 .. 17): storage row 1
+Row 3 (slots 18 .. 26): storage row 2
+Row 4 (slots 27 .. 35): storage row 3
+Row 5:
   36 = boots
   37 = leggings
-  38 = chestplate (or elytra)
+  38 = chestplate or elytra
   39 = helmet
   40 = offhand
-  41-44 = empty / locked
-Row 6 (slots 45 ..53): locked (decorative glass panes)
+  41-44 = locked decoration
+Row 6:
+  45 = auto-equip on save
+  48 = Save changes
+  49 = status and exact bot UUID
+  51 = Discard changes
+  53 = Close (discard)
+  other slots = locked decoration
 ```
 
 ## Interaction rules
 
-- **Click / drag**: normal Bukkit inventory behavior, with the usual stack-splitting shortcuts.
-- **Shift-click**: moves items between hotbar and storage as normal.
-- **Armor slots**: only accept the matching material class — putting a sword in the helmet slot is refused by vanilla.
-- **Locked slots**: any attempt to drop items into the bottom row is cancelled server-side.
+- Normal left and right clicks in the first 41 slots edit only the working copy.
+- The player's own inventory is locked while the editor is open. Use
+  `/bot equipment give` to add a new stack before reopening the editor.
+- Shift-click, number-key swaps, double-click collection, offhand swaps,
+  creative actions, outside clicks, and drag events are cancelled.
+- Armor slots accept only their matching armor class (plus elytra in the
+  chest slot and carved pumpkins in the helmet slot). Invalid saves are refused.
+- Locked slots cannot receive or provide items.
 
 ## Saving
 
-Close the GUI (Escape / `E`) to push changes back to the bot:
+Changes are isolated until **Save changes** is clicked:
 
-1. Reads all 45 editable slots.
-2. Diffs against the bot's current inventory.
-3. Writes back via NMS `Inventory.setItem` so NBT (enchantments, custom names, durability) survives.
-4. Re-syncs the selected hotbar slot via packet so the bot's main hand reflects the change.
+1. The editor validates all equipment slots.
+2. The exact selected bot is rechecked and the 41-slot snapshot is applied.
+3. The selected hotbar slot is preserved unless optional auto-equip is enabled.
 
-There's no explicit "save" button — the close handler does it.
+**Discard changes** and **Close (discard)** leave the bot untouched and restore
+the item cursor to its state from when the editor opened. Closing the
+GUI with Escape or `E`, disconnecting, losing permission, removing the bot, or
+disabling the plugin also discards unsaved changes. There is one editor lock per
+bot, so two players cannot edit the same bot concurrently.
 
-## Why 54 slots?
-
-Bukkit chest inventories come in 27- or 54-slot sizes. 45 slots of editable space (5 rows) fit the 41-slot bot inventory with one spare row, and using a double chest gives you the visual affordance of "this is bigger than my own inventory" so it's obvious you're looking at the bot.
+Auto-equip is off by default. Enable it before saving only when the deterministic
+combat layout (best armor, prioritized hotbar, and offhand rules) is wanted; it
+may reorder items as part of that explicit save choice.
 
 ## Pairing with presets
 
 Typical workflow:
 
-1. `/bot create T1 + /bot loadout pvp T1` — get a starting kit.
-2. `/bot inventory T1` — fine-tune (add custom enchanted gear, edit durability, etc.).
-3. `/bot preset save mykit T1` — snapshot.
+1. `/bot spawn single T1` and `/bot equipment loadout pvp T1` — get a starting kit.
+2. `/bot equipment inventory T1` — edit it and click **Save changes**.
+3. `/bot preset save mykit T1` — snapshot the saved kit.
 
 See [Presets](Presets) for how the snapshot is stored.
 
 ## Permissions
 
-Opening the GUI requires `terminatorplus.manage` (default: op). See [Installation](Installation).
+Opening and editing the GUI requires `terminatorplus.manage` (default: op).
+Permission is rechecked for every action. See [Installation](Installation).

--- a/wiki/Loadouts.md
+++ b/wiki/Loadouts.md
@@ -168,4 +168,7 @@ configured `family=<name>` for all candidates.
 
 ## Saving your own
 
-Edit a bot's inventory with `/bot inventory <name>` and then run `/bot preset save <name> <bot>`. That YAML file can be re-applied via `/bot preset apply <name> [bot]`. See [Presets](Presets) for the file format.
+Edit a bot's inventory with `/bot equipment inventory <name>`, click **Save
+changes**, and then run `/bot preset save <name> <bot>`. That YAML file can be
+re-applied via `/bot preset apply <name> [bot]`. See [Presets](Presets) for the
+file format.

--- a/wiki/Presets.md
+++ b/wiki/Presets.md
@@ -63,7 +63,7 @@ Only non-empty slots are written; missing keys deserialize as `AIR`.
 You can open a preset file in any text editor. To drop an item, delete its key. To add one, you need a valid Base64 blob — the easiest way to produce one is:
 
 1. `/bot create T1`
-2. Edit T1's inventory with `/bot inventory T1` (place the exact item you want).
+2. Edit T1's inventory with `/bot equipment inventory T1`, then click **Save changes** (place the exact item you want).
 3. `/bot preset save scratch T1`
 4. Copy the relevant key from `scratch.yml` into your real preset.
 

--- a/wiki/Quick-Start.md
+++ b/wiki/Quick-Start.md
@@ -18,7 +18,8 @@ movement path unless it was spawned by `/ai movement`.
 ## Edit and Save a Kit
 
 ```text
-/bot inventory TestBot
+/bot equipment inventory TestBot
+# edit the working copy, then click Save changes
 /bot preset save mykit TestBot
 /bot create T2
 /bot preset apply mykit T2

--- a/wiki/Release-Notes-6.2.3.md
+++ b/wiki/Release-Notes-6.2.3.md
@@ -1,0 +1,28 @@
+# TerminatorPlus 6.2.3 - Paper 26.2 Prerelease
+
+TerminatorPlus 6.2.3 keeps the organized `/bot` command surface and replaces
+the bot inventory flow with an explicit, exact-target editor.
+
+## Highlights
+
+- Adds previous/next bot-page controls with clamped page state and empty-list
+  feedback in the management UI.
+- Rejects ambiguous name-based inventory commands and keeps the management-menu
+  inventory action tied to the selected bot UUID.
+- Makes inventory editing transactional: changes are local until **Save
+  changes**, while Discard, Close, disconnect, removal, permission loss, and
+  shutdown discard unsaved changes.
+- Blocks inventory shortcuts and transfer paths that bypass slot validation,
+  validates armor placement, and adds a one-editor-per-bot lock.
+- Makes auto-equip an explicit opt-in at save time and reports dispatch status
+  honestly in the management UI.
+
+## Compatibility and scope
+
+- Existing command aliases remain available.
+- This is a prerelease for Paper 26.2 and Java 25.
+- Live Paper acceptance testing is still required before a production rollout.
+
+## Artifact
+
+`TerminatorPlus-6.2.3-BETA-mc26.2.jar`


### PR DESCRIPTION
## Summary

- make the bot inventory editor explicit Save/Discard with exact UUID targeting
- add page boundaries, prompt cleanup, permission rechecks, confirmations, and honest dispatch feedback
- lock one editor per bot and block inventory bypass events
- update command/inventory documentation and bump the prerelease version to 6.2.3

## Verification

- `./gradlew test` (53 plugin tests, 0 failures)
- `./gradlew build -q`
- artifact: `TerminatorPlus-6.2.3-BETA-mc26.2.jar`