### PR TITLE
Enable Movement V2 by default in 6.2.4

### DIFF
--- a/TerminatorPlus-Plugin/src/main/java/net/nuggetmc/tplus/TerminatorPlus.java
+++ b/TerminatorPlus-Plugin/src/main/java/net/nuggetmc/tplus/TerminatorPlus.java
@@ -9,6 +9,7 @@ import net.nuggetmc.tplus.bot.combat.CombatDirector;
 import net.nuggetmc.tplus.bot.gui.BotInventoryListener;
 import net.nuggetmc.tplus.bot.gui.BotManagementUI;
 import net.nuggetmc.tplus.bot.movement.MovementOutputApplier;
+import net.nuggetmc.tplus.bot.navigation.MovementV2Settings;
 import net.nuggetmc.tplus.bot.preset.PresetManager;
 import net.nuggetmc.tplus.bridge.InternalBridgeImpl;
 import net.nuggetmc.tplus.command.CommandHandler;
@@ -81,6 +82,7 @@ public class TerminatorPlus extends JavaPlugin {
         instance = this;
         version = getDescription().getVersion();
         saveDefaultConfig();
+        MovementV2Settings.applyDefaultEnabledMigration(this);
 
         mcVersion = Bukkit.getServer().getMinecraftVersion();
         correctVersion = mcVersion.equals(REQUIRED_VERSION);

--- a/TerminatorPlus-Plugin/src/main/java/net/nuggetmc/tplus/bot/Bot.java
+++ b/TerminatorPlus-Plugin/src/main/java/net/nuggetmc/tplus/bot/Bot.java
@@ -50,6 +50,7 @@ import net.nuggetmc.tplus.bot.movement.MovementOutputApplier;
 import net.nuggetmc.tplus.bot.navigation.BukkitNavigationContext;
 import net.nuggetmc.tplus.bot.navigation.MovementV2Controller;
 import net.nuggetmc.tplus.bot.navigation.MovementV2Planner;
+import net.nuggetmc.tplus.bot.navigation.MovementV2Settings;
 import net.nuggetmc.tplus.command.commands.BotCommand;
 import net.nuggetmc.tplus.nms.MockConnection;
 import net.nuggetmc.tplus.utils.NMSUtils;
@@ -572,7 +573,7 @@ public class Bot extends ServerPlayer implements Terminator {
     }
 
     private boolean movementV2Enabled() {
-        return plugin.getConfig().getBoolean("ai.movement.v2.enabled", false);
+        return MovementV2Settings.isEnabled(plugin);
     }
 
     private boolean movementV2Flag(String name, boolean fallback) {

--- a/TerminatorPlus-Plugin/src/main/java/net/nuggetmc/tplus/bot/navigation/MovementV2Settings.java
+++ b/TerminatorPlus-Plugin/src/main/java/net/nuggetmc/tplus/bot/navigation/MovementV2Settings.java
@@ -2,17 +2,34 @@ package net.nuggetmc.tplus.bot.navigation;
 
 import net.nuggetmc.tplus.TerminatorPlus;
 import net.nuggetmc.tplus.bot.Bot;
+import org.bukkit.configuration.Configuration;
 
 /** Runtime feature gate shared by commands, UI, and bots. */
 public final class MovementV2Settings {
 
     public static final String CONFIG_PATH = "ai.movement.v2.enabled";
+    static final String DEFAULT_ENABLED_MIGRATION = "migrations.movement-v2-default-enabled-6-2-4";
 
     private MovementV2Settings() {
     }
 
     public static boolean isEnabled(TerminatorPlus plugin) {
-        return plugin.getConfig().getBoolean(CONFIG_PATH, false);
+        return plugin.getConfig().getBoolean(CONFIG_PATH, true);
+    }
+
+    public static void applyDefaultEnabledMigration(TerminatorPlus plugin) {
+        if (migrateDefaultEnabled(plugin.getConfig())) {
+            plugin.saveConfig();
+        }
+    }
+
+    static boolean migrateDefaultEnabled(Configuration config) {
+        if (config.getBoolean(DEFAULT_ENABLED_MIGRATION, false)) {
+            return false;
+        }
+        config.set(CONFIG_PATH, true);
+        config.set(DEFAULT_ENABLED_MIGRATION, true);
+        return true;
     }
 
     public static void setEnabled(TerminatorPlus plugin, boolean enabled) {

--- a/TerminatorPlus-Plugin/src/main/java/net/nuggetmc/tplus/command/commands/BotCommand.java
+++ b/TerminatorPlus-Plugin/src/main/java/net/nuggetmc/tplus/command/commands/BotCommand.java
@@ -38,8 +38,8 @@ public class BotCommand extends CommandInstance {
     private static final String ADMIN_PERMISSION = "terminatorplus.admin";
     static final double DEFAULT_SCATTER_RADIUS = 8.0;
     static final double MIN_SCATTER_RADIUS = 1.0;
-    static final double MAX_SCATTER_RADIUS = 64.0;
     private static final double SCATTER_MIN_SEPARATION = 0.75;
+    private static final int SCATTER_FALLBACK_RANGE = 4;
 
     private final TerminatorPlus plugin;
     private final BotManagerImpl manager;
@@ -1113,7 +1113,7 @@ public class BotCommand extends CommandInstance {
             radius = parseScatterRadius(radiusText);
         } catch (IllegalArgumentException e) {
             sender.sendMessage(ChatColor.RED + e.getMessage());
-            sender.sendMessage(ChatColor.GRAY + "Usage: /bot scatter [radius] (default "
+            sender.sendMessage(ChatColor.GRAY + "Usage: /bot move scatter [radius] (default "
                     + DEFAULT_SCATTER_RADIUS + ").");
             return;
         }
@@ -1159,12 +1159,12 @@ public class BotCommand extends CommandInstance {
         try {
             radius = Double.parseDouble(radiusText);
         } catch (NumberFormatException e) {
-            throw new IllegalArgumentException("Radius must be a number from " + MIN_SCATTER_RADIUS
-                    + " to " + MAX_SCATTER_RADIUS + ".");
+            throw new IllegalArgumentException("Radius must be a finite number of at least "
+                    + MIN_SCATTER_RADIUS + ".");
         }
-        if (!Double.isFinite(radius) || radius < MIN_SCATTER_RADIUS || radius > MAX_SCATTER_RADIUS) {
-            throw new IllegalArgumentException("Radius must be a number from " + MIN_SCATTER_RADIUS
-                    + " to " + MAX_SCATTER_RADIUS + ".");
+        if (!Double.isFinite(radius) || radius < MIN_SCATTER_RADIUS) {
+            throw new IllegalArgumentException("Radius must be a finite number of at least "
+                    + MIN_SCATTER_RADIUS + ".");
         }
         return radius;
     }
@@ -1232,25 +1232,24 @@ public class BotCommand extends CommandInstance {
         if (center == null || center.getWorld() == null || count <= 0) return List.of();
 
         Map<ScatterOffset, Location> candidates = new LinkedHashMap<>();
-        for (ScatterOffset offset : evenlySpacedOffsets(count, radius)) {
+        List<ScatterOffset> ideals = evenlySpacedOffsets(count, radius);
+        for (ScatterOffset offset : ideals) {
             addScatterCandidate(center, offset, candidates);
         }
 
-        int minX = (int) Math.floor(center.getX() - radius);
-        int maxX = (int) Math.floor(center.getX() + radius);
-        int minZ = (int) Math.floor(center.getZ() - radius);
-        int maxZ = (int) Math.floor(center.getZ() + radius);
-
-        // Deterministic block-center fallbacks cover blocked ideal points.
-        for (int x = minX; x <= maxX; x++) {
-            for (int z = minZ; z <= maxZ; z++) {
-                double candidateX = x + 0.5;
-                double candidateZ = z + 0.5;
-                double offsetX = candidateX - center.getX();
-                double offsetZ = candidateZ - center.getZ();
-                if (offsetX * offsetX + offsetZ * offsetZ > radius * radius
-                        || (x == center.getBlockX() && z == center.getBlockZ())) continue;
-                addScatterCandidate(center, new ScatterOffset(offsetX, offsetZ), candidates);
+        // Search a fixed neighbourhood around each ideal instead of scanning the
+        // whole circle, so runtime depends on bot count rather than radius.
+        for (ScatterOffset ideal : ideals) {
+            int idealX = Location.locToBlock(center.getX() + ideal.x());
+            int idealZ = Location.locToBlock(center.getZ() + ideal.z());
+            for (int dx = -SCATTER_FALLBACK_RANGE; dx <= SCATTER_FALLBACK_RANGE; dx++) {
+                for (int dz = -SCATTER_FALLBACK_RANGE; dz <= SCATTER_FALLBACK_RANGE; dz++) {
+                    double offsetX = idealX + dx + 0.5 - center.getX();
+                    double offsetZ = idealZ + dz + 0.5 - center.getZ();
+                    if (Math.hypot(offsetX, offsetZ) > radius
+                            || (idealX + dx == center.getBlockX() && idealZ + dz == center.getBlockZ())) continue;
+                    addScatterCandidate(center, new ScatterOffset(offsetX, offsetZ), candidates);
+                }
             }
         }
 

--- a/TerminatorPlus-Plugin/src/main/java/net/nuggetmc/tplus/command/commands/BotEnvironmentCommand.java
+++ b/TerminatorPlus-Plugin/src/main/java/net/nuggetmc/tplus/command/commands/BotEnvironmentCommand.java
@@ -19,6 +19,7 @@ import net.nuggetmc.tplus.api.utils.ChatUtils;
 import net.nuggetmc.tplus.bot.Bot;
 import net.nuggetmc.tplus.bot.navigation.BukkitNavigationContext;
 import net.nuggetmc.tplus.bot.navigation.MovementV2Controller;
+import net.nuggetmc.tplus.bot.navigation.MovementV2Settings;
 import net.nuggetmc.tplus.command.CommandHandler;
 import net.nuggetmc.tplus.command.CommandInstance;
 import net.nuggetmc.tplus.command.annotation.Arg;
@@ -385,7 +386,7 @@ public class BotEnvironmentCommand extends CommandInstance {
     )
     public void movementV2Status(CommandSender sender, List<String> args) {
         TerminatorPlus plugin = TerminatorPlus.getInstance();
-        boolean enabled = plugin.getConfig().getBoolean("ai.movement.v2.enabled", false);
+        boolean enabled = MovementV2Settings.isEnabled(plugin);
         String requested = args.isEmpty() ? null : args.get(0);
         List<Bot> bots = plugin.getManager().fetch().stream()
                 .filter(Bot.class::isInstance)

--- a/TerminatorPlus-Plugin/src/test/java/net/nuggetmc/tplus/bot/navigation/MovementV2SettingsTest.java
+++ b/TerminatorPlus-Plugin/src/test/java/net/nuggetmc/tplus/bot/navigation/MovementV2SettingsTest.java
@@ -1,0 +1,23 @@
+package net.nuggetmc.tplus.bot.navigation;
+
+import org.bukkit.configuration.MemoryConfiguration;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class MovementV2SettingsTest {
+
+    @Test
+    void migrationEnablesMovementV2OnceAndThenPreservesAdminChoice() {
+        MemoryConfiguration config = new MemoryConfiguration();
+        config.set(MovementV2Settings.CONFIG_PATH, false);
+
+        assertTrue(MovementV2Settings.migrateDefaultEnabled(config));
+        assertTrue(config.getBoolean(MovementV2Settings.CONFIG_PATH));
+
+        config.set(MovementV2Settings.CONFIG_PATH, false);
+        assertFalse(MovementV2Settings.migrateDefaultEnabled(config));
+        assertFalse(config.getBoolean(MovementV2Settings.CONFIG_PATH));
+    }
+}

--- a/TerminatorPlus-Plugin/src/test/java/net/nuggetmc/tplus/command/commands/BotCommandMovementV2Test.java
+++ b/TerminatorPlus-Plugin/src/test/java/net/nuggetmc/tplus/command/commands/BotCommandMovementV2Test.java
@@ -14,11 +14,11 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 class BotCommandMovementV2Test {
 
     @Test
-    void freshInstallDefaultsMovementV2Off() throws IOException {
+    void freshInstallDefaultsMovementV2On() throws IOException {
         String config = Files.readString(Path.of("..", "src", "main", "resources", "config.yml"));
 
         org.junit.jupiter.api.Assertions.assertTrue(
-                config.matches("(?s).*\\bv2:\\s*.*?\\benabled:\\s*false\\b.*"));
+                config.matches("(?s).*\\bv2:\\s*.*?\\benabled:\\s*true\\b.*"));
     }
 
     @Test

--- a/TerminatorPlus-Plugin/src/test/java/net/nuggetmc/tplus/command/commands/BotScatterPlacementTest.java
+++ b/TerminatorPlus-Plugin/src/test/java/net/nuggetmc/tplus/command/commands/BotScatterPlacementTest.java
@@ -24,6 +24,7 @@ class BotScatterPlacementTest {
     void defaultAndExplicitRadiusAreAccepted() {
         assertEquals(BotCommand.DEFAULT_SCATTER_RADIUS, BotCommand.parseScatterRadius(null));
         assertEquals(12.5, BotCommand.parseScatterRadius("12.5"));
+        assertEquals(1_000_000, BotCommand.parseScatterRadius("1000000"));
     }
 
     @Test
@@ -33,7 +34,6 @@ class BotScatterPlacementTest {
         assertThrows(IllegalArgumentException.class, () -> BotCommand.parseScatterRadius("0.5"));
         assertThrows(IllegalArgumentException.class, () -> BotCommand.parseScatterRadius("-2"));
         assertThrows(IllegalArgumentException.class, () -> BotCommand.parseScatterRadius("NaN"));
-        assertThrows(IllegalArgumentException.class, () -> BotCommand.parseScatterRadius("65"));
     }
 
     @Test

--- a/buildSrc/src/main/kotlin/net.nuggetmc.java-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/net.nuggetmc.java-conventions.gradle.kts
@@ -3,4 +3,4 @@ plugins {
 }
 
 group = "net.nuggetmc"
-version = "6.2.3-BETA-mc26.2"
+version = "6.2.4-BETA-mc26.2"

--- a/docs/MOVEMENT_V2.md
+++ b/docs/MOVEMENT_V2.md
@@ -71,7 +71,8 @@ the server thread; it must never receive a live Bukkit `World` or `Block`.
 
 ## Compatibility boundaries
 
-- The feature does nothing unless `ai.movement.v2.enabled` is `true`.
+- The feature is enabled by default. Version 6.2.4 also enables it once when an
+  existing installation upgrades; later admin changes persist.
 - The old movement and obstacle code remains the fallback.
 - Full-replacement neural-network mode is unchanged.
 - Movement training bots are excluded so saved fitness values are not silently
@@ -83,10 +84,11 @@ the server thread; it must never receive a live Bukkit `World` or `Block`.
 
 ## Status command
 
-Use `/botenvironment movementV2Status` for all active bots, or
-`/botenvironment movementV2Status <bot-name>` for one name. The command shows
-the current route position, plan/replan/fallback counts, action failures, the
-last reason, search phase, and expanded node count.
+Use `/bot settings movement-v2 status` to inspect the feature gate, and
+`/bot debug movement [bot-name]` for route diagnostics. The diagnostic command
+shows the current route position, plan/replan/fallback counts, action failures,
+the last reason, search phase, and expanded node count. The legacy
+`/botenvironment movementV2Status [bot-name]` path remains available.
 
 ## Assumptions checked during implementation
 

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -19,10 +19,9 @@ ai:
       legacy-import-behavior: import-compatible-or-reset
       debug-logging: false
     # Movement V2 actively plans within the bot's current chunk plus all eight
-    # neighbouring chunks. Keep the outer gate off until the Paper arena matrix
-    # has been recorded.
+    # neighbouring chunks. Disable it with /bot settings movement-v2 off.
     v2:
-      enabled: false
+      enabled: true
       max-nodes: 2048
       max-micros: 2000
       # Ordinary movement is hard-capped at three. Only a planned clutch may

--- a/wiki/Commands.md
+++ b/wiki/Commands.md
@@ -131,6 +131,8 @@ Teleport all bots to your location.
 
 ### `/bot move scatter [radius]`
 Distribute living bots in a safe circular spread around your location.
+The radius has no command-defined maximum; the world border still determines
+whether destinations are valid.
 
 ### `/bot debug behavior <expression>`
 Run a debugger behavior expression. **Requires** `terminatorplus.admin`.

--- a/wiki/Configuration.md
+++ b/wiki/Configuration.md
@@ -26,6 +26,8 @@ ai:
       quarantine-bad-files: true
       legacy-import-behavior: import-compatible-or-reset
       debug-logging: false
+    v2:
+      enabled: true
 ```
 
 | Key | Default | Description |
@@ -42,6 +44,10 @@ ai:
 | `ai.movement.bank.quarantine-bad-files` | `true` | Move bad manifests/brains aside instead of reusing them. |
 | `ai.movement.bank.legacy-import-behavior` | `import-compatible-or-reset` | Import compatible `ai/brain.json` as fallback, otherwise reset safely. |
 | `ai.movement.bank.debug-logging` | `false` | Log route changes to console. |
+| `ai.movement.v2.enabled` | `true` | Enables Movement V2 route planning. Version 6.2.4 enables it once during upgrade; later admin changes persist. |
+
+Use `/bot settings movement-v2 off` to disable Movement V2, or replace `off`
+with `on` or `status` to enable or inspect it.
 
 ## Training
 

--- a/wiki/Release-Notes-6.2.4.md
+++ b/wiki/Release-Notes-6.2.4.md
@@ -1,0 +1,14 @@
+# TerminatorPlus 6.2.4 - Minecraft 26.2
+
+This prerelease enables Movement V2 automatically.
+
+- New installations start with Movement V2 enabled.
+- Existing installations receive a one-time migration that enables Movement V2.
+- After migration, `/bot settings movement-v2 off` remains persistent across restarts.
+- Movement V2 can be inspected with `/bot settings movement-v2 status` and
+  `/bot debug movement [bot-name]`.
+
+Artifact: `TerminatorPlus-6.2.4-BETA-mc26.2.jar`
+
+This is a Paper 26.2 prerelease. Full live-server arena acceptance remains
+environment-dependent.

--- a/wiki/Release-Notes-6.2.4.md
+++ b/wiki/Release-Notes-6.2.4.md
@@ -7,6 +7,8 @@ This prerelease enables Movement V2 automatically.
 - After migration, `/bot settings movement-v2 off` remains persistent across restarts.
 - Movement V2 can be inspected with `/bot settings movement-v2 status` and
   `/bot debug movement [bot-name]`.
+- `/bot move scatter [radius]` no longer has a command-defined maximum radius;
+  destination validity is still constrained by the world border.
 
 Artifact: `TerminatorPlus-6.2.4-BETA-mc26.2.jar`
 


### PR DESCRIPTION
## Summary
- enable Movement V2 by default for new installations
- migrate existing installations to enabled once while preserving later admin choices
- remove the scatter command's maximum radius and keep fallback search proportional to bot count
- centralize Movement V2 gate reads and document 6.2.4

## Verification
- focused Movement V2 and scatter tests
- full Gradle test suite
- Gradle build