### PR TITLE
Add bot setspawn command

### DIFF
--- a/TerminatorPlus-Plugin/src/main/java/net/nuggetmc/tplus/bot/Bot.java
+++ b/TerminatorPlus-Plugin/src/main/java/net/nuggetmc/tplus/bot/Bot.java
@@ -1420,6 +1420,10 @@ public class Bot extends ServerPlayer implements Terminator {
         return respawnAnchor == null ? null : respawnAnchor.clone();
     }
 
+    public void setRespawnAnchor(Location location) {
+        respawnAnchor = location == null ? null : location.clone();
+    }
+
     SkinData skinData() {
         return skinData;
     }

--- a/TerminatorPlus-Plugin/src/main/java/net/nuggetmc/tplus/command/commands/BotCommand.java
+++ b/TerminatorPlus-Plugin/src/main/java/net/nuggetmc/tplus/command/commands/BotCommand.java
@@ -335,6 +335,43 @@ public class BotCommand extends CommandInstance {
         return args.length == 2 ? List.of("true", "false") : List.of();
     }
 
+    @Command(
+            name = "setspawn",
+            desc = "Set the respawn anchor for all living bots or one named bot.",
+            aliases = "set-spawn",
+            autofill = "setSpawnAutofill",
+            visible = false
+    )
+    @Require(ADMIN_PERMISSION)
+    public void setSpawn(CommandSender sender, @OptArg("bot-name") String botName) {
+        if (!(sender instanceof Player player)) {
+            sender.sendMessage(ChatColor.RED + "This command can only be run by a player.");
+            return;
+        }
+
+        List<Bot> bots = manager.fetch().stream()
+                .filter(Bot.class::isInstance)
+                .map(Bot.class::cast)
+                .filter(Bot::isBotAlive)
+                .filter(bot -> botName == null || bot.getBotName().equalsIgnoreCase(botName))
+                .toList();
+        if (bots.isEmpty()) {
+            sender.sendMessage(ChatColor.RED + (botName == null
+                    ? "No living bots were found."
+                    : "No living bot named " + botName + " was found."));
+            return;
+        }
+
+        Location spawn = player.getLocation();
+        bots.forEach(bot -> bot.setRespawnAnchor(spawn));
+        sender.sendMessage(ChatColor.YELLOW.toString() + bots.size() + ChatColor.RESET
+                + " bot respawn anchor(s) set to your location.");
+    }
+
+    public List<String> setSpawnAutofill(CommandSender sender, String[] args) {
+        return args.length == 2 ? manager.fetchNames() : List.of();
+    }
+
     static Boolean parseBoolean(String value) {
         if ("true".equalsIgnoreCase(value)) return true;
         if ("false".equalsIgnoreCase(value)) return false;
@@ -691,7 +728,7 @@ public class BotCommand extends CommandInstance {
         if (arg1 == null || (!arg1.equalsIgnoreCase("combat-goal") && !arg1.equalsIgnoreCase("target-mobs") && !arg1.equalsIgnoreCase("target-player")
                 && !arg1.equalsIgnoreCase("show-in-player-list") && !arg1.equalsIgnoreCase("target-region")
                 && !arg1.equalsIgnoreCase("auto-respawn") && !arg1.equalsIgnoreCase("movement-v2")
-                && !arg1.equalsIgnoreCase("placement-material"))) {
+                && !arg1.equalsIgnoreCase("set-spawn") && !arg1.equalsIgnoreCase("placement-material"))) {
             sender.sendMessage(ChatUtils.LINE);
             sender.sendMessage(ChatColor.GOLD + "Bot Settings" + extra);
             sender.sendMessage(ChatUtils.BULLET_FORMATTED + ChatColor.YELLOW + "combat-goal" + ChatUtils.BULLET_FORMATTED + "Set the global bot target selection method.");
@@ -700,6 +737,7 @@ public class BotCommand extends CommandInstance {
             sender.sendMessage(ChatUtils.BULLET_FORMATTED + ChatColor.YELLOW + "target-region" + ChatUtils.BULLET_FORMATTED + "Set a region for the bots to prioritize entities inside.");
             sender.sendMessage(ChatUtils.BULLET_FORMATTED + ChatColor.YELLOW + "show-in-player-list" + ChatUtils.BULLET_FORMATTED + "Add newly spawned bots to the player list.");
             sender.sendMessage(ChatUtils.BULLET_FORMATTED + ChatColor.YELLOW + "auto-respawn" + ChatUtils.BULLET_FORMATTED + "Enable or disable automatic bot respawning.");
+            sender.sendMessage(ChatUtils.BULLET_FORMATTED + ChatColor.YELLOW + "set-spawn" + ChatUtils.BULLET_FORMATTED + "Set bot respawn anchors to your location.");
             sender.sendMessage(ChatUtils.BULLET_FORMATTED + ChatColor.YELLOW + "movement-v2" + ChatUtils.BULLET_FORMATTED + "Enable, disable, or inspect Movement V2.");
             sender.sendMessage(ChatUtils.BULLET_FORMATTED + ChatColor.YELLOW + "placement-material" + ChatUtils.BULLET_FORMATTED + "Set the block bots use when placing blocks.");
             sender.sendMessage(ChatUtils.LINE);
@@ -843,6 +881,9 @@ public class BotCommand extends CommandInstance {
                 return;
             }
             respawn(sender, Boolean.toString(enabled));
+        } else if (arg1.equalsIgnoreCase("set-spawn")) {
+            if (!requireAdmin(sender)) return;
+            setSpawn(sender, arg2);
         } else if (arg1.equalsIgnoreCase("movement-v2")) {
             if (!requireAdmin(sender)) return;
             movementV2(sender, arg2);
@@ -865,6 +906,7 @@ public class BotCommand extends CommandInstance {
             output.add("target-region");
             output.add("show-in-player-list");
             output.add("auto-respawn");
+            output.add("set-spawn");
             output.add("movement-v2");
             output.add("placement-material");
         } else if (args.length == 3) {
@@ -881,6 +923,7 @@ public class BotCommand extends CommandInstance {
                     output.add(player.getName());
                 }
             }
+            if ("set-spawn".equals(action)) output.addAll(manager.fetchNames());
             if ("movement-v2".equals(action)) output.addAll(List.of("on", "off", "status"));
             if ("placement-material".equals(action)) output.addAll(placeAutofill(sender, new String[]{"place", args[2]}));
         }
@@ -2058,6 +2101,7 @@ public class BotCommand extends CommandInstance {
             case "region", "target-region" -> "target-region";
             case "addplayerlist", "show-in-player-list" -> "show-in-player-list";
             case "respawn", "auto-respawn" -> "auto-respawn";
+            case "setspawn", "set-spawn" -> "set-spawn";
             case "movementv2", "movement-v2" -> "movement-v2";
             case "place", "placement-material" -> "placement-material";
             default -> null;

--- a/TerminatorPlus-Plugin/src/test/java/net/nuggetmc/tplus/command/commands/BotCommandRespawnTest.java
+++ b/TerminatorPlus-Plugin/src/test/java/net/nuggetmc/tplus/command/commands/BotCommandRespawnTest.java
@@ -1,5 +1,7 @@
 package net.nuggetmc.tplus.command.commands;
 
+import net.nuggetmc.tplus.command.annotation.Require;
+import org.bukkit.command.CommandSender;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -13,5 +15,15 @@ class BotCommandRespawnTest {
         assertEquals(Boolean.FALSE, BotCommand.parseBoolean("false"));
         assertNull(BotCommand.parseBoolean("on"));
         assertNull(BotCommand.parseBoolean(""));
+    }
+
+    @Test
+    void setSpawnUsesAdminPermissionAndCanonicalName() throws NoSuchMethodException {
+        Require require = BotCommand.class
+                .getMethod("setSpawn", CommandSender.class, String.class)
+                .getAnnotation(Require.class);
+
+        assertEquals("terminatorplus.admin", require.value());
+        assertEquals("set-spawn", BotCommand.canonicalSettingsAction("setspawn"));
     }
 }

--- a/TerminatorPlus-Plugin/src/test/java/net/nuggetmc/tplus/command/commands/CommandOrganizationTest.java
+++ b/TerminatorPlus-Plugin/src/test/java/net/nuggetmc/tplus/command/commands/CommandOrganizationTest.java
@@ -19,7 +19,7 @@ class CommandOrganizationTest {
         for (String method : List.of("spawn", "inspect", "move", "equipment", "settings", "preset", "debug", "admin", "environment")) {
             assertTrue(command(BotCommand.class, method).visible(), method);
         }
-        for (String method : List.of("create", "multi", "give", "place", "armor", "info", "count", "reset", "weapons", "combatDebug", "gather", "scatter", "inventory", "loadout", "loadoutMix")) {
+        for (String method : List.of("create", "multi", "give", "place", "armor", "info", "count", "reset", "weapons", "combatDebug", "gather", "scatter", "setSpawn", "inventory", "loadout", "loadoutMix")) {
             assertFalse(command(BotCommand.class, method).visible(), method);
         }
     }
@@ -30,6 +30,7 @@ class CommandOrganizationTest {
         assertEquals("target-mobs", BotCommand.canonicalSettingsAction("mobtarget"));
         assertEquals("target-region", BotCommand.canonicalSettingsAction("TARGET-REGION"));
         assertEquals("movement-v2", BotCommand.canonicalSettingsAction("movementv2"));
+        assertEquals("set-spawn", BotCommand.canonicalSettingsAction("setspawn"));
         assertEquals("placement-material", BotCommand.canonicalSettingsAction("place"));
         assertEquals(null, BotCommand.canonicalSettingsAction("unknown"));
         assertEquals(EnumTargetGoal.NEAREST_HOSTILE, EnumTargetGoal.from("NEAREST-HOSTILE"));

--- a/wiki/Commands.md
+++ b/wiki/Commands.md
@@ -14,7 +14,7 @@ New command paths use the following groups. The older flat paths documented belo
 /bot spawn single|multiple
 /bot inspect list|info|weapons
 /bot move gather|scatter
-/bot settings combat-goal|target-mobs|target-player|target-region|show-in-player-list|auto-respawn|movement-v2|placement-material
+/bot settings combat-goal|target-mobs|target-player|target-region|show-in-player-list|auto-respawn|set-spawn|movement-v2|placement-material
 /bot equipment inventory|give|armor|loadout|mixed-loadout
 /bot preset save|apply|list|delete
 /bot debug behavior|combat|movement
@@ -120,6 +120,10 @@ Set region for bot prioritization.
 
 ### `/bot settings auto-respawn <true|false>`
 Enable or disable automatic bot respawning. **Requires** `terminatorplus.admin`.
+
+### `/bot settings set-spawn [bot-name]` (legacy `/bot setspawn [bot-name]`)
+Set the permanent respawn anchor of every living bot, or one named bot, to your
+current location. **Requires** `terminatorplus.admin` and must be run by a player.
 
 ### `/bot settings movement-v2 <on|off|status>`
 Enable, disable, or inspect Movement V2. **Requires** `terminatorplus.admin`.


### PR DESCRIPTION
## Summary
- add /bot setspawn [bot-name] for all living bots or one named bot
- expose the canonical /bot settings set-spawn [bot-name] path
- update the actual per-bot anchor consumed by automatic respawning
- require admin permission and player context

## Verification
- focused respawn and command organization tests
- full Gradle test suite
- Gradle build