### PR TITLE
Restore applied loadouts on autorespawn

### DIFF
--- a/TerminatorPlus-Plugin/src/main/java/net/nuggetmc/tplus/bot/BotRespawnState.java
+++ b/TerminatorPlus-Plugin/src/main/java/net/nuggetmc/tplus/bot/BotRespawnState.java
@@ -33,22 +33,22 @@ record BotRespawnState(
         Location anchor = bot.respawnAnchor();
         if (anchor == null) return null;
 
-        PlayerInventory inventory = bot.getBukkitEntity().getInventory();
+        var botInventory = bot.getBotInventory();
         return new BotRespawnState(
                 bot.getUUID(),
                 bot.getBotName(),
                 anchor,
                 bot.skinData(),
-                copy(inventory.getStorageContents()),
-                copy(inventory.getArmorContents()),
-                copy(inventory.getExtraContents()),
-                bot.getBotInventory().getSelectedHotbarSlot(),
+                botInventory.respawnStorageContents(),
+                botInventory.respawnArmorContents(),
+                botInventory.respawnExtraContents(),
+                botInventory.respawnSelectedHotbarSlot(),
                 cloneItem(bot.defaultItem),
                 bot.getNeuralNetwork(),
                 bot.hasShieldEnabled(),
                 bot.getTargetPlayer(),
                 bot.getKills(),
-                bot.getBotInventory().isRespectingLoadout(),
+                botInventory.isRespectingLoadout(),
                 bot.trainingLoadout(),
                 bot.isInPlayerList()
         );

--- a/TerminatorPlus-Plugin/src/main/java/net/nuggetmc/tplus/bot/loadout/BotInventory.java
+++ b/TerminatorPlus-Plugin/src/main/java/net/nuggetmc/tplus/bot/loadout/BotInventory.java
@@ -57,11 +57,13 @@ public final class BotInventory {
      * re-appear two seconds later, silently overwriting their intent.
      */
     private boolean respectLoadout;
+    private AppliedLoadout appliedLoadout;
 
     public BotInventory(Bot bot) {
         this.bot = bot;
         this.selectedHotbarSlot = 0;
         this.respectLoadout = false;
+        this.appliedLoadout = null;
     }
 
     /**
@@ -70,6 +72,12 @@ public final class BotInventory {
      * that the loadout chose to omit.
      */
     public void markLoadoutApplied() {
+        PlayerInventory inventory = raw();
+        this.appliedLoadout = new AppliedLoadout(
+                copy(inventory.getStorageContents()),
+                copy(inventory.getArmorContents()),
+                copy(inventory.getExtraContents()),
+                selectedHotbarSlot);
         this.respectLoadout = true;
     }
 
@@ -79,6 +87,7 @@ public final class BotInventory {
      */
     public void markLoadoutCleared() {
         this.respectLoadout = false;
+        this.appliedLoadout = null;
     }
 
     /**
@@ -87,6 +96,48 @@ public final class BotInventory {
      */
     public boolean isRespectingLoadout() {
         return respectLoadout;
+    }
+
+    public ItemStack[] respawnStorageContents() {
+        return respawnContents(respectLoadout,
+                appliedLoadout == null ? null : appliedLoadout.storage(), raw().getStorageContents());
+    }
+
+    public ItemStack[] respawnArmorContents() {
+        return respawnContents(respectLoadout,
+                appliedLoadout == null ? null : appliedLoadout.armor(), raw().getArmorContents());
+    }
+
+    public ItemStack[] respawnExtraContents() {
+        return respawnContents(respectLoadout,
+                appliedLoadout == null ? null : appliedLoadout.extra(), raw().getExtraContents());
+    }
+
+    public int respawnSelectedHotbarSlot() {
+        return respectLoadout && appliedLoadout != null
+                ? appliedLoadout.selectedHotbarSlot()
+                : selectedHotbarSlot;
+    }
+
+    static ItemStack[] respawnContents(boolean respectLoadout, ItemStack[] applied, ItemStack[] current) {
+        return copy(respectLoadout && applied != null ? applied : current);
+    }
+
+    private static ItemStack[] copy(ItemStack[] contents) {
+        if (contents == null) return new ItemStack[0];
+        ItemStack[] result = new ItemStack[contents.length];
+        for (int i = 0; i < contents.length; i++) {
+            result[i] = contents[i] == null ? null : contents[i].clone();
+        }
+        return result;
+    }
+
+    private record AppliedLoadout(
+            ItemStack[] storage,
+            ItemStack[] armor,
+            ItemStack[] extra,
+            int selectedHotbarSlot
+    ) {
     }
 
     public Bot getBot() {

--- a/TerminatorPlus-Plugin/src/main/java/net/nuggetmc/tplus/bot/preset/PresetManager.java
+++ b/TerminatorPlus-Plugin/src/main/java/net/nuggetmc/tplus/bot/preset/PresetManager.java
@@ -158,9 +158,9 @@ public final class PresetManager {
 
         int sel = p.selectedHotbarSlot != null ? p.selectedHotbarSlot : 0;
         bot.selectHotbarSlot(sel);
-        bot.getBotInventory().markLoadoutApplied();
 
         if (p.shield != null) bot.setShield(p.shield);
+        bot.getBotInventory().markLoadoutApplied();
 
         // Global settings (applies to all bots, not just this one).
         if (p.targetGoal != null && plugin.getManager().getAgent() instanceof LegacyAgent la) {

--- a/TerminatorPlus-Plugin/src/test/java/net/nuggetmc/tplus/bot/loadout/BotInventoryRespawnTest.java
+++ b/TerminatorPlus-Plugin/src/test/java/net/nuggetmc/tplus/bot/loadout/BotInventoryRespawnTest.java
@@ -1,0 +1,22 @@
+package net.nuggetmc.tplus.bot.loadout;
+
+import org.bukkit.inventory.ItemStack;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+
+class BotInventoryRespawnTest {
+
+    @Test
+    void appliedLoadoutWinsOverInventoryAtDeath() {
+        ItemStack[] original = new ItemStack[1];
+        ItemStack[] atDeath = new ItemStack[2];
+
+        ItemStack[] restored = BotInventory.respawnContents(true, original, atDeath);
+
+        assertEquals(1, restored.length);
+        assertNotSame(original, restored);
+        assertEquals(2, BotInventory.respawnContents(false, original, atDeath).length);
+    }
+}

--- a/wiki/Commands.md
+++ b/wiki/Commands.md
@@ -120,6 +120,8 @@ Set region for bot prioritization.
 
 ### `/bot settings auto-respawn <true|false>`
 Enable or disable automatic bot respawning. **Requires** `terminatorplus.admin`.
+Bots with an applied loadout respawn with that original loadout rather than
+their depleted inventory at death.
 
 ### `/bot settings set-spawn [bot-name]` (legacy `/bot setspawn [bot-name]`)
 Set the permanent respawn anchor of every living bot, or one named bot, to your


### PR DESCRIPTION
## Summary
- snapshot inventory, armor, offhand, and selected slot when a loadout is deliberately applied
- restore that original snapshot during autorespawn instead of the depleted death inventory
- preserve existing death-inventory restoration for bots without an applied loadout

## Verification
- focused loadout respawn and respawn-state tests
- full Gradle test suite
- Gradle build