### PR TITLE
Fix Movement V2 facing and sprinting for 6.2.5

### DIFF
--- a/TerminatorPlus-Plugin/src/main/java/net/nuggetmc/tplus/bot/Bot.java
+++ b/TerminatorPlus-Plugin/src/main/java/net/nuggetmc/tplus/bot/Bot.java
@@ -492,6 +492,7 @@ public class Bot extends ServerPlayer implements Terminator {
 
         lastMovementV2ControlledTick = getAliveTicks();
         if (decision.type() == MovementV2Controller.DecisionType.HOLD) {
+            setSprinting(false);
             walkRoute(new Vector());
             return true;
         }
@@ -540,9 +541,14 @@ public class Bot extends ServerPlayer implements Terminator {
     private void followMovementV2Step(org.bukkit.entity.LivingEntity target, MovementV2Planner.Step step) {
         Location waypoint = new Location(getBukkitEntity().getWorld(),
                 step.to().x() + 0.5, step.to().y(), step.to().z() + 0.5);
+        Vector delta = waypoint.toVector().subtract(getLocation().toVector());
+        Vector desired = delta.clone().setY(0);
+        if (desired.lengthSquared() > 1.0e-6) {
+            desired.normalize();
+            faceMovement(desired);
+        }
 
         if (step.kind() == MovementV2Planner.Kind.PARKOUR && isBotOnGround()) {
-            Vector delta = waypoint.toVector().subtract(getLocation().toVector());
             double horizontal = Math.hypot(delta.getX(), delta.getZ());
             int ticks = Math.max(4, (int) Math.ceil(horizontal / 0.42));
             double vy = Math.min(0.42,
@@ -553,9 +559,9 @@ public class Bot extends ServerPlayer implements Terminator {
             return;
         }
 
-        Vector desired = waypoint.toVector().subtract(getLocation().toVector()).setY(0);
-        if (desired.lengthSquared() > 1.0e-6) desired.normalize().multiply(0.36);
+        desired.multiply(0.4);
         if (step.kind() == MovementV2Planner.Kind.STEP_UP && isBotOnGround()) {
+            setSprinting(true);
             jump(new Vector(desired.getX(), 0.42, desired.getZ()));
             return;
         }
@@ -569,7 +575,14 @@ public class Bot extends ServerPlayer implements Terminator {
             if (!result.fallback()) return;
         }
 
+        setSprinting(true);
         walkRoute(desired);
+    }
+
+    private void faceMovement(Vector direction) {
+        if (direction != null && direction.lengthSquared() > 1.0e-6) {
+            faceLocation(getLocation().clone().add(direction));
+        }
     }
 
     private boolean movementV2Enabled() {
@@ -1739,11 +1752,14 @@ public class Bot extends ServerPlayer implements Terminator {
             float[] vals = MathUtils.fetchYawPitch(dir);
             yaw = vals[0];
             pitch = vals[1];
-
-            sendPacket(new ClientboundRotateHeadPacket(getBukkitEntity().getHandle(), (byte) (yaw * 256 / 360f)));
         }
 
         setRot(yaw, pitch);
+        setYHeadRot(yaw);
+        yBodyRot = yaw;
+        if (!keepYaw) {
+            sendPacket(new ClientboundRotateHeadPacket(this, (byte) (yaw * 256 / 360f)));
+        }
     }
 
     @Override

--- a/TerminatorPlus-Plugin/src/main/java/net/nuggetmc/tplus/bot/BotRespawnState.java
+++ b/TerminatorPlus-Plugin/src/main/java/net/nuggetmc/tplus/bot/BotRespawnState.java
@@ -72,6 +72,8 @@ record BotRespawnState(
         bot.restoreTrainingLoadout(trainingLoadout);
         if (respectLoadout) {
             bot.getBotInventory().markLoadoutApplied();
+        } else {
+            bot.getBotInventory().saveForRespawn();
         }
         bot.getBukkitEntity().updateInventory();
         RespawnSafety.emitPoof(bot.getLocation(), BotRespawnState::spawnPoof);

--- a/TerminatorPlus-Plugin/src/main/java/net/nuggetmc/tplus/bot/loadout/BotInventory.java
+++ b/TerminatorPlus-Plugin/src/main/java/net/nuggetmc/tplus/bot/loadout/BotInventory.java
@@ -57,13 +57,13 @@ public final class BotInventory {
      * re-appear two seconds later, silently overwriting their intent.
      */
     private boolean respectLoadout;
-    private AppliedLoadout appliedLoadout;
+    private SavedInventory savedInventory;
 
     public BotInventory(Bot bot) {
         this.bot = bot;
         this.selectedHotbarSlot = 0;
         this.respectLoadout = false;
-        this.appliedLoadout = null;
+        this.savedInventory = null;
     }
 
     /**
@@ -72,13 +72,18 @@ public final class BotInventory {
      * that the loadout chose to omit.
      */
     public void markLoadoutApplied() {
+        saveForRespawn();
+        this.respectLoadout = true;
+    }
+
+    /** Save the current deliberate inventory state for future autorespawns. */
+    public void saveForRespawn() {
         PlayerInventory inventory = raw();
-        this.appliedLoadout = new AppliedLoadout(
+        this.savedInventory = new SavedInventory(
                 copy(inventory.getStorageContents()),
                 copy(inventory.getArmorContents()),
                 copy(inventory.getExtraContents()),
                 selectedHotbarSlot);
-        this.respectLoadout = true;
     }
 
     /**
@@ -86,8 +91,8 @@ public final class BotInventory {
      * Called by the {@code clear} preset and by any future {@code /bot inv reset} path.
      */
     public void markLoadoutCleared() {
+        saveForRespawn();
         this.respectLoadout = false;
-        this.appliedLoadout = null;
     }
 
     /**
@@ -99,28 +104,25 @@ public final class BotInventory {
     }
 
     public ItemStack[] respawnStorageContents() {
-        return respawnContents(respectLoadout,
-                appliedLoadout == null ? null : appliedLoadout.storage(), raw().getStorageContents());
+        return respawnContents(savedInventory == null ? null : savedInventory.storage(), raw().getStorageContents());
     }
 
     public ItemStack[] respawnArmorContents() {
-        return respawnContents(respectLoadout,
-                appliedLoadout == null ? null : appliedLoadout.armor(), raw().getArmorContents());
+        return respawnContents(savedInventory == null ? null : savedInventory.armor(), raw().getArmorContents());
     }
 
     public ItemStack[] respawnExtraContents() {
-        return respawnContents(respectLoadout,
-                appliedLoadout == null ? null : appliedLoadout.extra(), raw().getExtraContents());
+        return respawnContents(savedInventory == null ? null : savedInventory.extra(), raw().getExtraContents());
     }
 
     public int respawnSelectedHotbarSlot() {
-        return respectLoadout && appliedLoadout != null
-                ? appliedLoadout.selectedHotbarSlot()
+        return savedInventory != null
+                ? savedInventory.selectedHotbarSlot()
                 : selectedHotbarSlot;
     }
 
-    static ItemStack[] respawnContents(boolean respectLoadout, ItemStack[] applied, ItemStack[] current) {
-        return copy(respectLoadout && applied != null ? applied : current);
+    static ItemStack[] respawnContents(ItemStack[] saved, ItemStack[] current) {
+        return copy(saved != null ? saved : current);
     }
 
     private static ItemStack[] copy(ItemStack[] contents) {
@@ -132,7 +134,7 @@ public final class BotInventory {
         return result;
     }
 
-    private record AppliedLoadout(
+    private record SavedInventory(
             ItemStack[] storage,
             ItemStack[] armor,
             ItemStack[] extra,

--- a/TerminatorPlus-Plugin/src/main/java/net/nuggetmc/tplus/bot/movement/MovementOutputApplier.java
+++ b/TerminatorPlus-Plugin/src/main/java/net/nuggetmc/tplus/bot/movement/MovementOutputApplier.java
@@ -233,10 +233,9 @@ public final class MovementOutputApplier {
         }
         if (desired.lengthSquared() > 1.0) desired.normalize();
 
-        boolean sprinting = output.sprintDesire() >= SPRINT_THRESHOLD
-                && (routeLocked || output.retreatDesire() < 0.55);
+        boolean sprinting = shouldSprint(routeLocked, output);
         bot.setSprinting(sprinting);
-        double speed = (sprinting ? SPRINT_SPEED : WALK_SPEED) * Math.max(0.25, output.urgency());
+        double speed = movementSpeed(routeLocked, sprinting, output.urgency());
         desired.multiply(speed);
 
         if (!routeLocked && output.jumpDesire() >= JUMP_THRESHOLD && bot.isBotOnGround()) {
@@ -246,6 +245,17 @@ public final class MovementOutputApplier {
         } else {
             bot.walk(desired);
         }
+    }
+
+    static boolean shouldSprint(boolean routeLocked, MovementOutput output) {
+        return routeLocked || (output.sprintDesire() >= SPRINT_THRESHOLD
+                && output.retreatDesire() < 0.55);
+    }
+
+    static double movementSpeed(boolean routeLocked, boolean sprinting, double urgency) {
+        return routeLocked
+                ? SPRINT_SPEED
+                : (sprinting ? SPRINT_SPEED : WALK_SPEED) * Math.max(0.25, urgency);
     }
 
     private static void writeObservedState(Bot bot, LivingEntity target, boolean justJumped) {

--- a/TerminatorPlus-Plugin/src/main/java/net/nuggetmc/tplus/command/commands/BotCommand.java
+++ b/TerminatorPlus-Plugin/src/main/java/net/nuggetmc/tplus/command/commands/BotCommand.java
@@ -483,6 +483,7 @@ public class BotCommand extends CommandInstance {
             return;
         }
         applyLoadoutSlot(bot, slot, item);
+        bot.getBotInventory().saveForRespawn();
         sender.sendMessage("Gave " + ChatColor.YELLOW + type + ChatColor.RESET + " to "
                 + ChatColor.GREEN + bot.getBotName() + ChatColor.RESET + " at slot "
                 + ChatColor.BLUE + slot + ChatColor.RESET + ".");
@@ -618,6 +619,7 @@ public class BotCommand extends CommandInstance {
                 bot.setItem(armor[1], EquipmentSlot.LEGS);
                 bot.setItem(armor[2], EquipmentSlot.CHEST);
                 bot.setItem(armor[3], EquipmentSlot.HEAD);
+                if (bot instanceof Bot concreteBot) concreteBot.getBotInventory().saveForRespawn();
             }
         });
 

--- a/TerminatorPlus-Plugin/src/test/java/net/nuggetmc/tplus/bot/loadout/BotInventoryRespawnTest.java
+++ b/TerminatorPlus-Plugin/src/test/java/net/nuggetmc/tplus/bot/loadout/BotInventoryRespawnTest.java
@@ -9,14 +9,14 @@ import static org.junit.jupiter.api.Assertions.assertNotSame;
 class BotInventoryRespawnTest {
 
     @Test
-    void appliedLoadoutWinsOverInventoryAtDeath() {
-        ItemStack[] original = new ItemStack[1];
+    void lastSavedInventoryWinsOverInventoryAtDeath() {
+        ItemStack[] saved = new ItemStack[1];
         ItemStack[] atDeath = new ItemStack[2];
 
-        ItemStack[] restored = BotInventory.respawnContents(true, original, atDeath);
+        ItemStack[] restored = BotInventory.respawnContents(saved, atDeath);
 
         assertEquals(1, restored.length);
-        assertNotSame(original, restored);
-        assertEquals(2, BotInventory.respawnContents(false, original, atDeath).length);
+        assertNotSame(saved, restored);
+        assertEquals(2, BotInventory.respawnContents(null, atDeath).length);
     }
 }

--- a/TerminatorPlus-Plugin/src/test/java/net/nuggetmc/tplus/bot/movement/MovementOutputApplierTest.java
+++ b/TerminatorPlus-Plugin/src/test/java/net/nuggetmc/tplus/bot/movement/MovementOutputApplierTest.java
@@ -1,0 +1,22 @@
+package net.nuggetmc.tplus.bot.movement;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class MovementOutputApplierTest {
+
+    @Test
+    void validatedRouteTraversalAlwaysSprints() {
+        assertTrue(MovementOutputApplier.shouldSprint(true, MovementOutput.ZERO));
+        assertFalse(MovementOutputApplier.shouldSprint(false, MovementOutput.ZERO));
+        assertTrue(MovementOutputApplier.shouldSprint(false,
+                new MovementOutput(1, 0, 0, 0.6, 0, 0, 1, 0)));
+        assertFalse(MovementOutputApplier.shouldSprint(false,
+                new MovementOutput(1, 0, 0, 1, 0.6, 0, 1, 0)));
+        assertEquals(0.42, MovementOutputApplier.movementSpeed(true, true, 0.0));
+        assertEquals(0.08, MovementOutputApplier.movementSpeed(false, false, 0.0));
+    }
+}

--- a/buildSrc/src/main/kotlin/net.nuggetmc.java-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/net.nuggetmc.java-conventions.gradle.kts
@@ -3,4 +3,4 @@ plugins {
 }
 
 group = "net.nuggetmc"
-version = "6.2.4-BETA-mc26.2"
+version = "6.2.5-BETA-mc26.2"

--- a/docs/MOVEMENT_V2.md
+++ b/docs/MOVEMENT_V2.md
@@ -81,6 +81,8 @@ the server thread; it must never receive a live Bukkit `World` or `Block`.
   intent. A route waypoint changes only where its locomotion output steers.
 - Existing combat policy still decides whether to approach, hold, commit, or
   use a combat item. Movement V2 does not attack or choose combat tactics.
+- Route traversal aligns head and body yaw with the validated movement vector
+  and sprints until the route requests a hold or traversal action.
 
 ## Status command
 

--- a/wiki/Commands.md
+++ b/wiki/Commands.md
@@ -120,8 +120,9 @@ Set region for bot prioritization.
 
 ### `/bot settings auto-respawn <true|false>`
 Enable or disable automatic bot respawning. **Requires** `terminatorplus.admin`.
-Bots with an applied loadout respawn with that original loadout rather than
-their depleted inventory at death.
+Bots respawn with their last deliberately saved inventory rather than their
+depleted inventory at death. Applying a loadout, saving the inventory editor,
+or using the give/armor commands updates that saved inventory.
 
 ### `/bot settings set-spawn [bot-name]` (legacy `/bot setspawn [bot-name]`)
 Set the permanent respawn anchor of every living bot, or one named bot, to your

--- a/wiki/Release-Notes-6.2.5.md
+++ b/wiki/Release-Notes-6.2.5.md
@@ -1,0 +1,15 @@
+# TerminatorPlus 6.2.5 - Minecraft 26.2
+
+This prerelease improves Movement V2 locomotion and autorespawn inventory restoration.
+
+- Movement V2 aligns bot head and body yaw with each validated route vector.
+- Validated routes sprint at full route speed, including normal, step-up, parkour,
+  and movement-controller traversal; route holds stop sprinting.
+- Autorespawn restores the last deliberately saved inventory instead of the
+  depleted inventory at death, whether or not a loadout lock is active.
+- Give, armor, loadout, preset, and inventory-editor saves update the respawn snapshot.
+
+Artifact: `TerminatorPlus-6.2.5-BETA-mc26.2.jar`
+
+This is a Paper 26.2 prerelease. Full live-server arena acceptance remains
+environment-dependent.


### PR DESCRIPTION
## Summary
- align bot head and body yaw with each validated Movement V2 route vector
- sprint validated routes at full route speed, including normal, step-up, parkour, and movement-controller traversal
- restore the last deliberately saved inventory on autorespawn, including without a loadout lock
- bump the prerelease version to 6.2.5

## Verification
- focused Movement V2 locomotion and autorespawn tests
- full Gradle test suite
- Gradle build