### PR TITLE
Release 6.2.6: deterministic Movement V2 by default

### DIFF
--- a/TerminatorPlus-Plugin/src/main/java/net/nuggetmc/tplus/bot/movement/MovementOutputApplier.java
+++ b/TerminatorPlus-Plugin/src/main/java/net/nuggetmc/tplus/bot/movement/MovementOutputApplier.java
@@ -9,6 +9,7 @@ import net.nuggetmc.tplus.bot.combat.CombatDebugger;
 import net.nuggetmc.tplus.bot.combat.CombatIntent;
 import net.nuggetmc.tplus.bot.combat.MovementState;
 import org.bukkit.Location;
+import org.bukkit.configuration.Configuration;
 import org.bukkit.entity.LivingEntity;
 import org.bukkit.util.Vector;
 
@@ -85,7 +86,9 @@ public final class MovementOutputApplier {
         boolean nnAvailable = false;
         String fallbackReason = "";
 
-        if (bank == null) {
+        if (!neuralEnabled()) {
+            fallbackReason = "neural-disabled";
+        } else if (bank == null) {
             fallbackReason = "missing-bank";
         } else {
             MovementBrainRouter.RouteResult route = router.route(bot, bank);
@@ -309,6 +312,15 @@ public final class MovementOutputApplier {
             return plugin.getConfig().getBoolean("ai.movement.bank.enabled");
         }
         return plugin.getConfig().getBoolean("ai.movement.enabled", true);
+    }
+
+    private static boolean neuralEnabled() {
+        TerminatorPlus plugin = TerminatorPlus.getInstance();
+        return plugin != null && neuralEnabled(plugin.getConfig());
+    }
+
+    static boolean neuralEnabled(Configuration config) {
+        return config != null && config.getBoolean("ai.movement.neural-enabled", false);
     }
 
     public record ApplyResult(boolean applied, boolean fallback, boolean held, String reason, MovementOutput output) {

--- a/TerminatorPlus-Plugin/src/main/java/net/nuggetmc/tplus/bot/movement/MovementOutputMixer.java
+++ b/TerminatorPlus-Plugin/src/main/java/net/nuggetmc/tplus/bot/movement/MovementOutputMixer.java
@@ -49,7 +49,7 @@ public final class MovementOutputMixer {
                 blend(baseline.forwardPressure(), nn.forwardPressure(), RESIDUAL_WEIGHT),
                 blend(baseline.strafePressure(), nn.strafePressure(), RESIDUAL_WEIGHT),
                 blend(baseline.jumpDesire(), nn.jumpDesire(), RESIDUAL_WEIGHT),
-                blend(baseline.sprintDesire(), nn.sprintDesire(), RESIDUAL_WEIGHT),
+                Math.max(baseline.sprintDesire(), blend(baseline.sprintDesire(), nn.sprintDesire(), RESIDUAL_WEIGHT)),
                 Math.max(baseline.retreatDesire(), nn.retreatDesire() * NN_WEIGHT),
                 blend(baseline.facingAdjustment(), nn.facingAdjustment(), RESIDUAL_WEIGHT),
                 Math.max(baseline.urgency(), nn.urgency() * NN_WEIGHT),

--- a/TerminatorPlus-Plugin/src/test/java/net/nuggetmc/tplus/bot/movement/MovementOutputApplierTest.java
+++ b/TerminatorPlus-Plugin/src/test/java/net/nuggetmc/tplus/bot/movement/MovementOutputApplierTest.java
@@ -1,5 +1,6 @@
 package net.nuggetmc.tplus.bot.movement;
 
+import org.bukkit.configuration.MemoryConfiguration;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -7,6 +8,15 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class MovementOutputApplierTest {
+
+    @Test
+    void neuralMovementIsOptIn() {
+        MemoryConfiguration config = new MemoryConfiguration();
+
+        assertFalse(MovementOutputApplier.neuralEnabled(config));
+        config.set("ai.movement.neural-enabled", true);
+        assertTrue(MovementOutputApplier.neuralEnabled(config));
+    }
 
     @Test
     void validatedRouteTraversalAlwaysSprints() {

--- a/TerminatorPlus-Plugin/src/test/java/net/nuggetmc/tplus/bot/movement/MovementOutputMixerTest.java
+++ b/TerminatorPlus-Plugin/src/test/java/net/nuggetmc/tplus/bot/movement/MovementOutputMixerTest.java
@@ -1,0 +1,20 @@
+package net.nuggetmc.tplus.bot.movement;
+
+import net.nuggetmc.tplus.bot.combat.CombatIntent;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class MovementOutputMixerTest {
+
+    @Test
+    void neuralResidualCannotCancelBaselineSprint() {
+        MovementOutput baseline = new MovementOutput(.85, .15, 0, .65, 0, 0, .65, 0);
+        MovementOutputMixer mixer = new MovementOutputMixer();
+
+        MovementOutputMixer.MixResult result = mixer.mix(
+                CombatIntent.DEFAULT, baseline, MovementOutput.ZERO, true);
+
+        assertEquals(.65, result.output().sprintDesire(), 1.0e-12);
+    }
+}

--- a/buildSrc/src/main/kotlin/net.nuggetmc.java-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/net.nuggetmc.java-conventions.gradle.kts
@@ -3,4 +3,4 @@ plugins {
 }
 
 group = "net.nuggetmc"
-version = "6.2.5-BETA-mc26.2"
+version = "6.2.6-BETA-mc26.2"

--- a/docs/MOVEMENT_V2.md
+++ b/docs/MOVEMENT_V2.md
@@ -79,6 +79,9 @@ the server thread; it must never receive a live Bukkit `World` or `Block`.
   measured against a different movement system.
 - The movement neural network still observes the real opponent and combat
   intent. A route waypoint changes only where its locomotion output steers.
+- The movement neural network is optional. With
+  `ai.movement.neural-enabled: false`, V2 routing stays active and ordinary
+  locomotion uses the deterministic baseline policy.
 - Existing combat policy still decides whether to approach, hold, commit, or
   use a combat item. Movement V2 does not attack or choose combat tactics.
 - Route traversal aligns head and body yaw with the validated movement vector

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -3,6 +3,9 @@ ai:
     # Movement-controller brains are locomotion-only. CombatDirector owns all combat actions.
     enabled: true
     mode: movement_controller
+    # Keep Movement V2 routing and deterministic baseline movement without
+    # evaluating movement-brain neural networks unless explicitly enabled.
+    neural-enabled: false
     # Must match MovementNetworkShape: 37 inputs, hidden layers, 8 movement outputs.
     layer-shape: [37, 32, 16, 8]
     # Legacy import source. Compatible files import as general_fallback.

--- a/wiki/Configuration.md
+++ b/wiki/Configuration.md
@@ -14,6 +14,7 @@ ai:
   movement:
     enabled: true
     mode: movement_controller
+    neural-enabled: false
     layer-shape: [37, 32, 16, 8]
     legacy-brain-path: ai/brain.json
     bank:
@@ -34,6 +35,7 @@ ai:
 | --- | --- | --- |
 | `ai.movement.enabled` | `true` | Enables movement-controller evaluation for bots spawned with a movement bank. |
 | `ai.movement.mode` | `movement_controller` | Current movement-controller mode name. |
+| `ai.movement.neural-enabled` | `false` | Enables movement-brain evaluation. When false, Movement V2 routing and deterministic baseline movement remain active. |
 | `ai.movement.layer-shape` | `[37, 32, 16, 8]` | Input count, hidden layers, output count. Changing it invalidates existing brains. |
 | `ai.movement.legacy-brain-path` | `ai/brain.json` | Legacy import source. |
 | `ai.movement.bank.manifest-path` | `ai/movement/manifest.json` | Bank manifest path. |

--- a/wiki/Release-Notes-6.2.6.md
+++ b/wiki/Release-Notes-6.2.6.md
@@ -1,0 +1,18 @@
+# TerminatorPlus 6.2.6 - mc26.2
+
+This prerelease makes Movement V2 deterministic by default while retaining an
+explicit neural-movement option.
+
+## Changes
+
+- Added `ai.movement.neural-enabled`, defaulting to `false`.
+- Movement V2 route planning remains active when neural movement is disabled.
+- Ordinary movement uses the deterministic baseline when neural movement is disabled.
+- Neural residual output can no longer cancel a baseline sprint decision.
+
+## Validation
+
+- Added regression coverage for the neural feature gate and sprint floor.
+- Full Gradle build and automated tests pass.
+
+Live duel behavior still needs a runtime Paper server test.


### PR DESCRIPTION
Adds the neural movement feature gate, defaults neural movement off while retaining Movement V2 routing, preserves baseline sprint decisions, bumps the plugin to 6.2.6, and adds release notes and regression tests. Full Gradle build passes.