### PR TITLE
Fix bot NPC UUID generation for 6.2.7

### DIFF
--- a/TerminatorPlus-API/src/main/java/net/nuggetmc/tplus/api/utils/BotUtils.java
+++ b/TerminatorPlus-API/src/main/java/net/nuggetmc/tplus/api/utils/BotUtils.java
@@ -26,13 +26,14 @@ public class BotUtils {
     ));
 
     public static UUID randomSteveUUID() {
-        UUID uuid = UUID.randomUUID();
-
-        if (uuid.hashCode() % 2 == 0) {
-            return uuid;
+        while (true) {
+            UUID random = UUID.randomUUID();
+            long npcMostSignificantBits = random.getMostSignificantBits() & 0xffffffffffff0fffL | 0x2000L;
+            UUID uuid = new UUID(npcMostSignificantBits, random.getLeastSignificantBits());
+            if ((uuid.hashCode() & 1) == 0) {
+                return uuid;
+            }
         }
-
-        return randomSteveUUID();
     }
 
     public static boolean overlaps(BoundingBox playerBox, BoundingBox blockBox) {

--- a/TerminatorPlus-API/src/test/java/net/nuggetmc/tplus/api/utils/BotUtilsTest.java
+++ b/TerminatorPlus-API/src/test/java/net/nuggetmc/tplus/api/utils/BotUtilsTest.java
@@ -1,0 +1,27 @@
+package net.nuggetmc.tplus.api.utils;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.HashSet;
+import java.util.Set;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class BotUtilsTest {
+
+    @Test
+    void generatedBotIdsAreUniqueNpcIdsWithSteveParity() {
+        Set<UUID> ids = new HashSet<>();
+
+        for (int i = 0; i < 512; i++) {
+            UUID id = BotUtils.randomSteveUUID();
+            assertEquals(2, id.version());
+            assertEquals(2, id.variant());
+            assertEquals(0, id.hashCode() & 1);
+            ids.add(id);
+        }
+
+        assertEquals(512, ids.size());
+    }
+}

--- a/buildSrc/src/main/kotlin/net.nuggetmc.java-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/net.nuggetmc.java-conventions.gradle.kts
@@ -3,4 +3,4 @@ plugins {
 }
 
 group = "net.nuggetmc"
-version = "6.2.6-BETA-mc26.2"
+version = "6.2.7-BETA-mc26.2"

--- a/wiki/Release-Notes-6.2.7.md
+++ b/wiki/Release-Notes-6.2.7.md
@@ -1,0 +1,21 @@
+# TerminatorPlus 6.2.7 - mc26.2
+
+This prerelease fixes LuckPerms/Vault main-thread lookup warnings for bots.
+
+## Fixed
+
+- Bot UUIDs are generated as version-2 NPC UUIDs so LuckPerms routes Vault
+  permission and metadata checks through its configured NPC group instead of
+  attempting an offline-player database lookup on the server thread.
+- Restored the UUID regression test that was present on the 6.2.0 release
+  branch but was accidentally omitted when later releases resumed from
+  `master`.
+
+## Validation
+
+- The UUID regression test verifies 512 generated bot IDs are unique,
+  version-2 NPC UUIDs with the expected player-skin parity.
+- Full Gradle build and automated tests pass.
+
+Runtime verification with LuckPerms, Vault, and the reporter's larger plugin
+stack is still recommended.


### PR DESCRIPTION
## Summary

- restore version-2 NPC UUID generation for all newly created bots
- restore the regression test that verifies UUID type, uniqueness, and skin parity
- prepare the 6.2.7 mc26.2 prerelease

## Cause

The fix shipped from the separate 6.2.0 release branch in `ca7f0dc`, but later releases resumed from `master`, where that commit had never been merged. As a result, 6.2.1 through 6.2.6 generated version-4 UUIDs and LuckPerms treated bots as offline players.

## Validation

- `./gradlew build -q`
- generated `TerminatorPlus-6.2.7-BETA-mc26.2.jar`
